### PR TITLE
FIX: allow setting custom http scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ bootstrap/cache/
 !.env.testing
 invoices.csv
 testlog.out
+
+# ides
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# staged
+
+- FIX: allow setting custom http scheme
+
 # v2.4.2
 
 - Dependancy updates

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "~6.5",
         "mockery/mockery": "1.0.*",
-        "codedungeon/phpunit-result-printer": "^0.5.3",
+        "codedungeon/phpunit-result-printer": "^0.19",
         "illuminate/support": "^5.4",
         "orchestra/testbench": "~3.4",
         "hirak/prestissimo": "^0.3.7"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee323d8e27c887d5aa3da1cb993cce5b",
+    "content-hash": "38db93ab83377fa8bda7f92fb104072e",
     "packages": [
         {
             "name": "ethical-jobs/laravel-storage",
@@ -349,26 +349,72 @@
     ],
     "packages-dev": [
         {
-            "name": "codedungeon/phpunit-result-printer",
-            "version": "0.5.4",
+            "name": "codedungeon/php-cli-colors",
+            "version": "1.10.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikeerickson/phpunit-pretty-result-printer.git",
-                "reference": "ce3b989eeb6d2b8cab367897275e120520bdca18"
+                "url": "https://github.com/mikeerickson/php-cli-colors.git",
+                "reference": "5649ef76ec0c9ed626e95bf40fdfaf4b8efcf79b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/ce3b989eeb6d2b8cab367897275e120520bdca18",
-                "reference": "ce3b989eeb6d2b8cab367897275e120520bdca18",
+                "url": "https://api.github.com/repos/mikeerickson/php-cli-colors/zipball/5649ef76ec0c9ed626e95bf40fdfaf4b8efcf79b",
+                "reference": "5649ef76ec0c9ed626e95bf40fdfaf4b8efcf79b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Codedungeon\\PHPCliColors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Erickson",
+                    "email": "codedungeon@gmail.com"
+                }
+            ],
+            "description": "PHP Package for using color output in CLI commands",
+            "homepage": "https://github.com/mikeerickson/php-cli-colors",
+            "keywords": [
+                "color",
+                "colors",
+                "composer",
+                "package",
+                "php"
+            ],
+            "time": "2018-05-17T01:34:14+00:00"
+        },
+        {
+            "name": "codedungeon/phpunit-result-printer",
+            "version": "0.19.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikeerickson/phpunit-pretty-result-printer.git",
+                "reference": "3ff0ebbfeca8cf57e0493b9a0a45f22a70626989"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/3ff0ebbfeca8cf57e0493b9a0a45f22a70626989",
+                "reference": "3ff0ebbfeca8cf57e0493b9a0a45f22a70626989",
                 "shasum": ""
             },
             "require": {
+                "codedungeon/php-cli-colors": "^1.10",
                 "hassankhan/config": "^0.10.0",
+                "php": "^7.1",
                 "symfony/yaml": "^2.7|^3.0|^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=5.2",
-                "spatie/phpunit-watcher": "^1.3"
+                "phpunit/phpunit": "7.1.1",
+                "spatie/phpunit-watcher": "^1.5"
             },
             "type": "library",
             "autoload": {
@@ -388,13 +434,15 @@
             ],
             "description": "PHPUnit Pretty Result Printer",
             "keywords": [
+                "TDD",
                 "composer",
                 "package",
                 "phpunit",
                 "printer",
-                "result-printer"
+                "result-printer",
+                "testing"
             ],
-            "time": "2018-01-24T00:13:26+00:00"
+            "time": "2018-05-24T02:02:32+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/src/Router.php
+++ b/src/Router.php
@@ -13,26 +13,17 @@ use Illuminate\Support\Facades\App;
 class Router
 {
 	/**
-	 * Returns full URL for a requet route
+	 * Returns full URL for a request route
 	 * 
 	 * @param string $route
 	 * @return string
 	 */
 	public static function getRouteUrl(string $route)
 	{
-		switch (App::environment()) {
-			case 'testing':
-				$scheme = 'http://';
-				break;			
-			default:
-				$scheme = 'https://';
-				break;
-		}
+		$host = env('API_HOST') ?? 'https://api.ethicaljobs.com.au';
 
-		$host = env('API_HOST') ?? 'api.ethicaljobs.com.au';
-
-		return $scheme.$host.self::sanitizeRoute($route);
-	}	
+		return $host.self::sanitizeRoute($route);
+	}
 
    	/**
    	 * Return route to the resource

--- a/tests/Integration/Authentication/TokenAuthenticatorTest.php
+++ b/tests/Integration/Authentication/TokenAuthenticatorTest.php
@@ -35,7 +35,7 @@ class TokenAuthenticatorTest extends \Tests\TestCase
             ->once()
             ->withArgs([
                 'POST',
-                'http://api.ethicaljobs.com.au/oauth/token',
+                'https://api.ethicaljobs.com.au/oauth/token',
                 [
                     'json' => [
                         'grant_type'    => 'password',

--- a/tests/Integration/HttpClient/HttpVerbTest.php
+++ b/tests/Integration/HttpClient/HttpVerbTest.php
@@ -11,6 +11,12 @@ use EthicalJobs\SDK\HttpClient;
 
 class HttpVerbTest extends \Tests\TestCase
 {
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
     /**
      * @test
      * @group Unit
@@ -38,7 +44,7 @@ class HttpVerbTest extends \Tests\TestCase
 
             $expected = new Request(
                 strtoupper($verb), 
-                'http://api.ethicaljobs.com.au/jobs', 
+                'https://api.ethicaljobs.com.au/jobs',
                 [
                     'Content-Type' => 'application/json',
                     'Accept'       => 'application/json',
@@ -80,7 +86,7 @@ class HttpVerbTest extends \Tests\TestCase
 
         $expected = new Request(
             'GET',
-            'http://api.ethicaljobs.com.au/repos?username=andrewmclagan&forks=0&repos=1',
+            'https://api.ethicaljobs.com.au/repos?username=andrewmclagan&forks=0&repos=1',
             [
                 'Content-Type'  => 'application/json',
                 'Accept'        => 'application/json',

--- a/tests/Integration/RouterTest.php
+++ b/tests/Integration/RouterTest.php
@@ -13,17 +13,17 @@ class RouterTest extends \Tests\TestCase
      */
     public function it_returns_correct_urls_for_host()
     {
-        putenv('API_HOST=api.ethicaljobs.com.au');
-        App::shouldReceive('environment')->once()->andReturn('production');
+        putenv('API_HOST'); // omitting value removes the env var
         $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
 
-        putenv('API_HOST=api.ethicalstaging.com.au');
-        App::shouldReceive('environment')->once()->andReturn('staging');
+        putenv('API_HOST=https://api.ethicaljobs.com.au');
+        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
+
+        putenv('API_HOST=https://api.ethicalstaging.com.au');
         $this->assertEquals('https://api.ethicalstaging.com.au/jobs', Router::getRouteUrl('jobs'));
 
-        putenv('API_HOST=api.whatever.com.au');
-        App::shouldReceive('environment')->once()->andReturn('testing');
-        $this->assertEquals('http://api.whatever.com.au/jobs', Router::getRouteUrl('jobs'));
+        putenv('API_HOST=http://api-local');
+        $this->assertEquals('http://api-local/jobs', Router::getRouteUrl('jobs'));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 	{
 	    parent::setUp();
 
-	    putenv('API_HOST=api.ethicaljobs.com.au');
+	    putenv('API_HOST=https://api.ethicaljobs.com.au');
 	}
 
 	/**


### PR DESCRIPTION
Allows you to use http on your local rather than having to use https. E.g. set local env variable `API_HOST=http://api-app`