### PR TITLE
Fix: remove scheme from API_HOST

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -20,9 +20,11 @@ class Router
 	 */
 	public static function getRouteUrl(string $route)
 	{
-		$host = env('API_HOST') ?? 'https://api.ethicaljobs.com.au';
+		$host = env('API_HOST') ?? 'api.ethicaljobs.com.au';
 
-		return $host.self::sanitizeRoute($route);
+		$scheme = env('API_SCHEME') ?? 'https';
+
+		return $scheme . '://' . $host . self::sanitizeRoute($route);
 	}
 
    	/**

--- a/tests/Integration/Authentication/TokenAuthenticatorTest.php
+++ b/tests/Integration/Authentication/TokenAuthenticatorTest.php
@@ -35,7 +35,7 @@ class TokenAuthenticatorTest extends \Tests\TestCase
             ->once()
             ->withArgs([
                 'POST',
-                'https://api.ethicaljobs.com.au/oauth/token',
+                'https://api.ethicalstaging.com.au/oauth/token',
                 [
                     'json' => [
                         'grant_type'    => 'password',

--- a/tests/Integration/HttpClient/HttpVerbTest.php
+++ b/tests/Integration/HttpClient/HttpVerbTest.php
@@ -44,7 +44,7 @@ class HttpVerbTest extends \Tests\TestCase
 
             $expected = new Request(
                 strtoupper($verb), 
-                'https://api.ethicaljobs.com.au/jobs',
+                'https://api.ethicalstaging.com.au/jobs',
                 [
                     'Content-Type' => 'application/json',
                     'Accept'       => 'application/json',
@@ -86,7 +86,7 @@ class HttpVerbTest extends \Tests\TestCase
 
         $expected = new Request(
             'GET',
-            'https://api.ethicaljobs.com.au/repos?username=andrewmclagan&forks=0&repos=1',
+            'https://api.ethicalstaging.com.au/repos?username=andrewmclagan&forks=0&repos=1',
             [
                 'Content-Type'  => 'application/json',
                 'Accept'        => 'application/json',

--- a/tests/Integration/RouterTest.php
+++ b/tests/Integration/RouterTest.php
@@ -14,15 +14,27 @@ class RouterTest extends \Tests\TestCase
     public function it_returns_correct_urls_for_host()
     {
         putenv('API_HOST'); // omitting value removes the env var
+        putenv('API_SCHEME');
         $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
 
-        putenv('API_HOST=https://api.ethicaljobs.com.au');
+        putenv('API_HOST');
+        putenv('API_SCHEME=https');
         $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
 
-        putenv('API_HOST=https://api.ethicalstaging.com.au');
+        putenv('API_HOST=api.ethicaljobs.com.au');
+        putenv('API_SCHEME');
+        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
+
+        putenv('API_HOST=api.ethicaljobs.com.au');
+        putenv('API_SCHEME=https');
+        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
+
+        putenv('API_HOST=api.ethicalstaging.com.au');
+        putenv('API_SCHEME=https');
         $this->assertEquals('https://api.ethicalstaging.com.au/jobs', Router::getRouteUrl('jobs'));
 
-        putenv('API_HOST=http://api-local');
+        putenv('API_HOST=api-local');
+        putenv('API_SCHEME=http');
         $this->assertEquals('http://api-local/jobs', Router::getRouteUrl('jobs'));
     }
 
@@ -35,11 +47,11 @@ class RouterTest extends \Tests\TestCase
         App::shouldReceive('environment')->andReturn('production');
 
         $this->assertEquals(
-            'https://api.ethicaljobs.com.au/route/to/jobs', 
+            'https://api.ethicalstaging.com.au/route/to/jobs',
             Router::getRouteUrl('route/to/jobs')
         );
         $this->assertEquals(
-            'https://api.ethicaljobs.com.au/route/to/jobs', 
+            'https://api.ethicalstaging.com.au/route/to/jobs',
             Router::getRouteUrl('/route/to/jobs')
         );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 	{
 	    parent::setUp();
 
-	    putenv('API_HOST=https://api.ethicaljobs.com.au');
+	    putenv('API_HOST=api.ethicalstaging.com.au'); // don't use production in case a test mutates data
+	    putenv('API_SCHEME=https');
 	}
 
 	/**


### PR DESCRIPTION
This reverts PR #1. And attempts to fix it in another way.

Issues:

1. API_HOST should not have a scheme, a hostname should not have a scheme.
2. We need to use http sometimes (e.g. inside the cluster) but https other times (from outside the cluster).
3. We want to use an internal hostname sometimes (e.g. inside the cluster) and the public hostname other times (from outside the cluster).

This fixes issues 1 and 2, applications can choose which scheme to use, and issue 3, applications can choose which hostname to use.