### PR TITLE
Feature/ats 81 shorter lifetime access tokens

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,17 +1,20 @@
-pipeline:
+kind: pipeline
+name: default
+steps:
 
-  dependancies:
+  - name: dependancies
     image: ethicaljobs/composer-prestissimo
     commands: 
       - 'composer install --prefer-dist --ignore-platform-reqs'
   
-  test:
+  - name: test
     image: php:7.2-cli-alpine
     commands: 
       - 'php vendor/bin/phpunit'
 
-  notify-slack:
+  - name: notify-slack
     image: plugins/slack
-    webhook: https://hooks.slack.com/services/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
-    channel: deployments
-
+    settings:
+      webhook:
+        from_secret: slack_webhook
+      channel: deployments

--- a/src/Authentication/AccessTokenFetcher.php
+++ b/src/Authentication/AccessTokenFetcher.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace EthicalJobs\SDK\Authentication;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Response;
+use EthicalJobs\SDK\Router;
+
+class AccessTokenFetcher
+{
+
+    /**
+     * Guzzle client
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Http credentials
+     *
+     * @var array
+     */
+    protected $credentials = [
+        'client_id' => '',
+        'client_secret' => '',
+        'username' => '',
+        'password' => '',
+    ];
+
+    public function __construct(Client $client, Array $credentials = [])
+    {
+        $this->client = $client;
+
+        $this->credentials = $credentials;
+    }
+
+    /**
+     * Fetches an Auth token
+     *
+     * @return string
+     * @throws GuzzleException
+     */
+    public function fetchToken(): string
+    {
+        $route = Router::getRouteUrl('/oauth/token');
+
+        $json = array_merge([
+            'grant_type' => 'password',
+            'scope' => '*',
+        ], $this->credentials);
+
+        $response = $this->tokenRequest($route, $json);
+
+        if ($response->getStatusCode() > 199 && $response->getStatusCode() < 300) {
+            if ($decoded = json_decode($response->getBody())) {
+                return $decoded->access_token ?? '';
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Fetches an Auth token
+     *
+     * @return Response
+     * @throws ClientException
+     * @throws GuzzleException
+     */
+    protected function tokenRequest(string $route, array $params): Response
+    {
+        try {
+            return $this->client->request('POST', $route, ['json' => $params]);
+        } catch (ClientException $exception) {
+            if (in_array($exception->getResponse()->getStatusCode(), [401, 403])) {
+                throw new ClientException(
+                    'Unauthorized SDK Request',
+                    $exception->getRequest(),
+                    $exception->getResponse(),
+                    null,
+                    $exception->getHandlerContext()
+                );
+            }
+            throw $exception;
+        }
+    }
+
+}

--- a/src/Authentication/Authenticator.php
+++ b/src/Authentication/Authenticator.php
@@ -18,4 +18,10 @@ interface Authenticator
      * @return Request
      */
     public function authenticate(Request $request);
+
+    /**
+     * Forgets cached auth token
+     *
+     */
+    public function reset();
 }

--- a/src/Authentication/NullAuthenticator.php
+++ b/src/Authentication/NullAuthenticator.php
@@ -18,4 +18,9 @@ class NullAuthenticator implements Authenticator
     {
         return $request;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset() {}
 }

--- a/src/Authentication/TokenAuthenticator.php
+++ b/src/Authentication/TokenAuthenticator.php
@@ -20,13 +20,6 @@ class TokenAuthenticator implements Authenticator
     protected $tokenKey = 'ej:pkg:sdk:token';
 
     /**
-     * Auth token cache lifespan (minutes)
-     *
-     * @var string
-     */
-    protected $tokenTTL = 45; // refresh the token every 45 minutes (accounts for token expiring after 1 hour)
-
-    /**
      * @var AccessTokenFetcher $accessTokenFetcher
      */
     protected $accessTokenFetcher;
@@ -68,9 +61,16 @@ class TokenAuthenticator implements Authenticator
      */
     public function getToken(): string
     {
-        return $this->cache->remember($this->tokenKey, $this->tokenTTL, function () {
+        return $this->cache->rememberForever($this->tokenKey, function () {
             return $this->accessTokenFetcher->fetchToken();
         });
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->cache->forget($this->tokenKey);
+    }
 }

--- a/src/Authentication/TokenAuthenticator.php
+++ b/src/Authentication/TokenAuthenticator.php
@@ -24,7 +24,7 @@ class TokenAuthenticator implements Authenticator
      *
      * @var string
      */
-    protected $tokenTTL = 1080; // refresh the token once a week
+    protected $tokenTTL = 45; // refresh the token every 45 minutes (accounts for token expiring after 1 hour)
 
     /**
      * @var AccessTokenFetcher $accessTokenFetcher

--- a/tests/Integration/Authentication/AccessTokenFetcherTest.php
+++ b/tests/Integration/Authentication/AccessTokenFetcherTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Integration\Authentication;
+
+use EthicalJobs\SDK\ApiClient;
+use EthicalJobs\SDK\Authentication\AccessTokenFetcher;
+use EthicalJobs\SDK\Authentication\TokenAuthenticator;
+use EthicalJobs\SDK\Testing\ResponseFactory;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Contracts\Cache\Repository;
+use Mockery;
+use Tests\TestCase;
+
+class AccessTokenFetcherTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_fetch()
+    {
+        $credentials = [
+            'client_id' => '21',
+            'client_secret' => 'aksus73j37sh363hsjs83h37sh363hsjksmde',
+            'username' => 'service-account@ethicaljobs.com.au',
+            'password' => 'slipery-squid-legs',
+        ];
+
+        $response = ResponseFactory::response(200, ResponseFactory::authentication());
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('request')
+            ->once()
+            ->withArgs([
+                'POST',
+                'https://api.ethicalstaging.com.au/oauth/token',
+                [
+                    'json' => [
+                        'grant_type' => 'password',
+                        'scope' => '*',
+                        'client_id' => $credentials['client_id'],
+                        'client_secret' => $credentials['client_secret'],
+                        'username' => $credentials['username'],
+                        'password' => $credentials['password'],
+                    ],
+                ],
+            ])
+            ->andReturn($response)
+            ->getMock();
+
+        $accessTokenFetcher = new AccessTokenFetcher($client, $credentials);
+
+        $token = $accessTokenFetcher->fetchToken();
+
+        $this->assertEquals(ResponseFactory::token(), $token);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_correct_exception_on_401()
+    {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Unauthorized SDK Request');
+
+        $clientException = $this->createClientException(401, 'Unauthorized');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('request')
+            ->once()
+            ->andThrow($clientException)
+            ->getMock();
+
+        $accessTokenFetcher = new AccessTokenFetcher($client, []);
+
+        $accessTokenFetcher->fetchToken();
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_correct_exception_on_403()
+    {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Unauthorized SDK Request');
+
+        $clientException = $this->createClientException(403, 'Unauthorized');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('request')
+            ->once()
+            ->andThrow($clientException)
+            ->getMock();
+
+        $accessTokenFetcher = new AccessTokenFetcher($client, []);
+
+        $accessTokenFetcher->fetchToken();
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_modify_non_auth_exceptions()
+    {
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Not Found');
+
+        $clientException = $this->createClientException(404, 'Not Found');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('request')
+            ->once()
+            ->andThrow($clientException)
+            ->getMock();
+
+        $accessTokenFetcher = new AccessTokenFetcher($client, []);
+
+        $accessTokenFetcher->fetchToken();
+    }
+
+    protected function createClientException($statusCode, $message) {
+        $request = new Request('GET', 'https://github.com/stars');
+
+        $response = ResponseFactory::response($statusCode, '');
+
+        return new ClientException($message, $request, $response);
+    }
+
+}

--- a/tests/Integration/Authentication/AccessTokenFetcherTest.php
+++ b/tests/Integration/Authentication/AccessTokenFetcherTest.php
@@ -118,13 +118,4 @@ class AccessTokenFetcherTest extends TestCase
 
         $accessTokenFetcher->fetchToken();
     }
-
-    protected function createClientException($statusCode, $message) {
-        $request = new Request('GET', 'https://github.com/stars');
-
-        $response = ResponseFactory::response($statusCode, '');
-
-        return new ClientException($message, $request, $response);
-    }
-
 }

--- a/tests/Integration/Authentication/TokenAuthenticatorTest.php
+++ b/tests/Integration/Authentication/TokenAuthenticatorTest.php
@@ -31,7 +31,7 @@ class TokenAuthenticatorTest extends TestCase
             ->once()
             ->withArgs([
                 'ej:pkg:sdk:token',
-                1080,
+                45,
                 Mockery::on(function ($callback) {
                     $this->assertEquals('my token :)', $callback());
 

--- a/tests/Integration/Authentication/TokenAuthenticatorTest.php
+++ b/tests/Integration/Authentication/TokenAuthenticatorTest.php
@@ -27,11 +27,10 @@ class TokenAuthenticatorTest extends TestCase
             ->getMock();
 
         $cache = Mockery::mock(Repository::class)
-            ->shouldReceive('remember')
+            ->shouldReceive('rememberForever')
             ->once()
             ->withArgs([
                 'ej:pkg:sdk:token',
-                45,
                 Mockery::on(function ($callback) {
                     $this->assertEquals('my token :)', $callback());
 

--- a/tests/Integration/HttpClient/HttpAuthenticationTest.php
+++ b/tests/Integration/HttpClient/HttpAuthenticationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Integration\HttpClient;
 use EthicalJobs\SDK\Authentication\NullAuthenticator;
 use EthicalJobs\SDK\HttpClient;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
@@ -85,5 +86,90 @@ class HttpAuthenticationTest extends TestCase
         $http->request('GET', '/jobs');
 
         $http->request('GET', '/jobs');
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_fetches_new_token_and_replays_request_when_request_fails_due_to_invalid_token()
+    {
+        $clientException = $this->createClientException(401, 'Unauthenticated.');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('send')
+            ->once()
+            ->andThrow($clientException)
+            ->shouldReceive('send')
+            ->once()
+            ->andReturn(new Response)
+            ->getMock();
+
+        $auth = Mockery::mock(NullAuthenticator::class)
+            ->shouldReceive('reset')
+            ->times(1)
+            ->shouldReceive('authenticate')
+            ->times(2)
+            ->andReturn(new Request('GET', 'http://github.com'))
+            ->getMock();
+
+        $http = new HttpClient($client, $auth);
+
+        $http->authenticate()->request('GET', '/jobs');
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_does_not_fetch_new_token_to_replace_invalid_token_when_authenticate_not_called()
+    {
+        $clientException = $this->createClientException(401, 'Unauthenticated.');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('send')
+            ->once()
+            ->andThrow($clientException)
+            ->getMock();
+
+        $auth = Mockery::mock(NullAuthenticator::class)
+            ->shouldReceive('authenticate')
+            ->never()
+            ->getMock();
+
+        $this->expectException(ClientException::class);
+
+        $http = new HttpClient($client, $auth);
+
+        $http->request('GET', '/jobs');
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_only_attempts_fetching_new_token_once_when_request_fails_due_to_401()
+    {
+        $clientException = $this->createClientException(401, 'Unauthenticated.');
+
+        $client = Mockery::mock(Client::class)
+            ->shouldReceive('send')
+            ->twice()
+            ->andThrow($clientException)
+            ->getMock();
+
+        $auth = Mockery::mock(NullAuthenticator::class)
+            ->shouldReceive('reset')
+            ->times(1)
+            ->shouldReceive('authenticate')
+            ->times(2)
+            ->andReturn(new Request('GET', 'http://github.com'))
+            ->getMock();
+
+        $this->expectException(ClientException::class);
+
+        $http = new HttpClient($client, $auth);
+
+        $http->authenticate()->request('GET', '/jobs');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,9 @@
 namespace Tests;
 
 use EthicalJobs\SDK\Laravel\ServiceProvider;
+use EthicalJobs\SDK\Testing\ResponseFactory;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
 use Illuminate\Contracts\Foundation\Application;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
@@ -31,5 +34,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         return [
             ServiceProvider::class,
         ];
+    }
+
+    protected function createClientException($statusCode, $message) {
+        $request = new Request('GET', 'https://github.com/stars');
+
+        $response = ResponseFactory::response($statusCode, '');
+
+        return new ClientException($message, $request, $response);
     }
 }


### PR DESCRIPTION
I had a look at doing this the robust way, i.e. caching the access token forever, and if we get back a 401/403 fetch a new access token and re-send the original request, just like the client side does now.

But it's 5pm and I've run out of time, so I dropped the cache TTL to less than an hour. Feel free to do the robust solution on top of this if you like, the refactor I've done here should make it a whole lot easier.