### PR TITLE
Upgrade to min PHP 8.0 (intended for 8.1) and drop laravel-storage dependency

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,30 +1,18 @@
-name: PHPUnit suite
+name: tests
 
-on:
-  push:
-    branches: [ master ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'phpunit.xml'
-      - 'composer.*'
-  pull_request:
-    branches: [ master ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'phpunit.xml'
-      - 'composer.*'
+on: [pull_request]
 
 jobs:
-  phpunit-tests:
+  tests:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.3, 7.4 ]
+        php: [8.0, 8.1]
+        stability: [prefer-lowest, prefer-stable]
 
-    name: PHPUnit (PHP ${{ matrix.php }})
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -34,16 +22,18 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
-          tools: composer:v2
-          coverage: none
+          extensions: bcmul
+          coverage: pcov
 
       - name: Install dependencies
-        run: |
-          composer install --no-plugins --no-scripts --no-interaction --no-progress --prefer-dist
-
-      - name: Configure matchers
-        uses: mheap/phpunit-matcher-action@v1
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --teamcity
+        run: vendor/bin/phpunit --verbose --coverage-clover=coverage.clover
+
+# @TODO: Consider adding this!
+#      - name: Code coverage
+#        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'thephpleague/oauth2-server' }}
+#        run: |
+#          wget https://scrutinizer-ci.com/ocular.phar
+#          php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ All current EJ packages will be taken offline by mid-2021 in order to re-release
 
 ## Compatibility
 
- - `v4.*` - Laravel 8 or higher
+ - `v8.*` - Laravel 8 or higher, PHP >8.x,<9.x
+ - `v4.*` - Laravel 8 or higher, PHP 7.3
  - `v3.*` - Laravel 7 or lower (possibly only 5.6 to 5.9)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,17 @@
   "description": "EthicalJobs API client and SDK",
   "license": "MIT",
   "require": {
-    "php": "^7.3",
-    "guzzlehttp/guzzle": "~6.0 || ~7.0",
-    "ethical-jobs/laravel-storage": "^v2.0.0",
-    "ext-json": "*"
+    "php": "~8.0",
+    "ext-json": "*",
+    "guzzlehttp/guzzle": "^7.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
-    "mockery/mockery": "^1.4",
-    "codedungeon/phpunit-result-printer": "^0.30",
-    "illuminate/support": "^8.34",
-    "orchestra/testbench": "^6.0"
+    "phpunit/phpunit": "^9.5",
+    "mockery/mockery": "^1.5",
+    "orchestra/testbench": "^7.6",
+    "orchestra/database": "*",
+    "roave/security-advisories": "dev-latest",
+    "laravel/legacy-factories": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,127 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21f1669850dd74a202783e54c1adba93",
+    "content-hash": "19c8ca2f7fa0ac7396e662215eec1238",
     "packages": [
         {
-            "name": "ethical-jobs/laravel-storage",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ethical-jobs/laravel-storage.git",
-                "reference": "85c052f6f776df1a8643026c504f0dd9818e9505"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ethical-jobs/laravel-storage/zipball/85c052f6f776df1a8643026c504f0dd9818e9505",
-                "reference": "85c052f6f776df1a8643026c504f0dd9818e9505",
-                "shasum": ""
-            },
-            "require": {
-                "ethical-jobs/utilities": "^1.0",
-                "ext-json": "*",
-                "php": "^7.3"
-            },
-            "require-dev": {
-                "fakerphp/faker": "^1.13",
-                "mockery/mockery": "^1.4",
-                "orchestra/database": "^5.1",
-                "orchestra/testbench": "^5.0",
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "EthicalJobs\\Storage\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Laravel repository storage package",
-            "support": {
-                "issues": "https://github.com/ethical-jobs/laravel-storage/issues",
-                "source": "https://github.com/ethical-jobs/laravel-storage/tree/v2.0.0"
-            },
-            "time": "2021-04-07T00:44:44+00:00"
-        },
-        {
-            "name": "ethical-jobs/utilities",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ethical-jobs/utilities-php.git",
-                "reference": "04584432ce33e6acc656e731ad8ae715777f14c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ethical-jobs/utilities-php/zipball/04584432ce33e6acc656e731ad8ae715777f14c0",
-                "reference": "04584432ce33e6acc656e731ad8ae715777f14c0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "codedungeon/phpunit-result-printer": "^0.5.3",
-                "hirak/prestissimo": "^0.3.7",
-                "mockery/mockery": "1.0.*",
-                "orchestra/database": "~3.5",
-                "orchestra/testbench": "~3.5",
-                "phpunit/phpunit": "~6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "EthicalJobs\\Utilities\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "EthicalJobs.com.au",
-                    "homepage": "http://ethicaljobs.com.au"
-                },
-                {
-                    "name": "Andrew McLagan",
-                    "email": "andrew@ethicaljobs.com.au"
-                }
-            ],
-            "description": "EthicalJobs supporting utilities",
-            "homepage": "https://github.com/ethical-jobs/utilities-php",
-            "keywords": [
-                "ethicaljobs",
-                "utilities",
-                "utils"
-            ],
-            "support": {
-                "issues": "https://github.com/ethical-jobs/utilities-php/issues",
-                "source": "https://github.com/ethical-jobs/utilities-php/tree/master"
-            },
-            "time": "2019-04-04T01:26:59+00:00"
-        },
-        {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.1",
+            "version": "7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79"
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
-                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
+                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "guzzlehttp/psr7": "^1.9 || ^2.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -151,12 +50,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -213,7 +112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.5"
             },
             "funding": [
                 {
@@ -229,7 +128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-06T18:43:05+00:00"
+            "time": "2022-06-20T22:16:13+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -258,12 +157,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -317,16 +216,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.1.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72"
+                "reference": "13388f00956b1503577598873fffb5ae994b5737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
-                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
+                "reference": "13388f00956b1503577598873fffb5ae994b5737",
                 "shasum": ""
             },
             "require": {
@@ -350,7 +249,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -412,7 +311,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.1.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
             },
             "funding": [
                 {
@@ -428,7 +327,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-06T17:43:30+00:00"
+            "time": "2022-06-20T21:43:11+00:00"
         },
         {
             "name": "psr/http-client",
@@ -636,25 +535,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
+                "reference": "07f1b9cc2ffee6aaafcf4b710fbc38ff736bd918",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -683,7 +582,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -699,59 +598,10 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-02-25T11:15:52+00:00"
         }
     ],
     "packages-dev": [
-        {
-            "name": "2bj/phanybar",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/2bj/Phanybar.git",
-                "reference": "88ff671e18f30c2047a34f8cf2465a7ff93c819b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/2bj/Phanybar/zipball/88ff671e18f30c2047a34f8cf2465a7ff93c819b",
-                "reference": "88ff671e18f30c2047a34f8cf2465a7ff93c819b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "bin": [
-                "bin/phanybar"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Bakyt\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bakyt Turgumbaev",
-                    "email": "dev2bj@gmail.com"
-                }
-            ],
-            "description": "Control AnyBar from your php",
-            "keywords": [
-                "anybar",
-                "phanybar"
-            ],
-            "support": {
-                "issues": "https://github.com/2bj/Phanybar/issues",
-                "source": "https://github.com/2bj/Phanybar/tree/master"
-            },
-            "time": "2015-03-06T12:14:28+00:00"
-        },
         {
             "name": "brick/math",
             "version": "0.9.3",
@@ -813,81 +663,38 @@
             "time": "2021-08-15T20:50:18+00:00"
         },
         {
-            "name": "codedungeon/php-cli-colors",
-            "version": "1.12.2",
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikeerickson/php-cli-colors.git",
-                "reference": "e346156f75717140a3dd622124d2ec686aa7ff8e"
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikeerickson/php-cli-colors/zipball/e346156f75717140a3dd622124d2ec686aa7ff8e",
-                "reference": "e346156f75717140a3dd622124d2ec686aa7ff8e",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Codedungeon\\PHPCliColors\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike Erickson",
-                    "email": "codedungeon@gmail.com"
-                }
-            ],
-            "description": "Liven up you PHP Console Apps with standard colors",
-            "homepage": "https://github.com/mikeerickson/php-cli-colors",
-            "keywords": [
-                "color",
-                "colors",
-                "composer",
-                "package",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/mikeerickson/php-cli-colors/issues",
-                "source": "https://github.com/mikeerickson/php-cli-colors/tree/1.12.2"
-            },
-            "time": "2021-01-05T04:48:27+00:00"
-        },
-        {
-            "name": "codedungeon/phpunit-result-printer",
-            "version": "0.30.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mikeerickson/phpunit-pretty-result-printer.git",
-                "reference": "a361009eeb7078c1478ba835976f7722a4952870"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/a361009eeb7078c1478ba835976f7722a4952870",
-                "reference": "a361009eeb7078c1478ba835976f7722a4952870",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
                 "shasum": ""
             },
             "require": {
-                "2bj/phanybar": "^1.0",
-                "codedungeon/php-cli-colors": "^1.10.2",
-                "hassankhan/config": "^0.11.2|^1.0|^2.0",
-                "php": "^7.1 | ^8.0",
-                "symfony/yaml": "^2.7|^3.0|^4.0|^5.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "spatie/phpunit-watcher": "^1.6"
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^3.14"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Codedungeon\\PHPUnitPrettyResultPrinter\\": "src/"
+                    "Dflydev\\DotAccessData\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -896,25 +703,39 @@
             ],
             "authors": [
                 {
-                    "name": "Mike Erickson",
-                    "email": "codedungeon@gmail.com"
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
-            "description": "PHPUnit Pretty Result Printer",
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
             "keywords": [
-                "TDD",
-                "composer",
-                "package",
-                "phpunit",
-                "printer",
-                "result-printer",
-                "testing"
+                "access",
+                "data",
+                "dot",
+                "notation"
             ],
             "support": {
-                "issues": "https://github.com/mikeerickson/phpunit-pretty-result-printer/issues",
-                "source": "https://github.com/mikeerickson/phpunit-pretty-result-printer/tree/0.30.1"
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
             },
-            "time": "2020-12-24T20:19:03+00:00"
+            "time": "2021-08-13T13:06:58+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1009,29 +830,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -1058,7 +880,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -1074,36 +896,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
-                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^8.2"
+                "doctrine/coding-standard": "^9.0",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.11"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
@@ -1138,7 +956,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
+                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -1154,33 +972,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-25T17:44:05+00:00"
+            "time": "2022-02-28T11:07:21+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v3.1.0",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "7a8c6e56ab3ffcc538d05e8155bb42269abf1a0c"
+                "reference": "be85b3f05b46c39bbc0d95f6c071ddff669510fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/7a8c6e56ab3ffcc538d05e8155bb42269abf1a0c",
-                "reference": "7a8c6e56ab3ffcc538d05e8155bb42269abf1a0c",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/be85b3f05b46c39bbc0d95f6c071ddff669510fa",
+                "reference": "be85b3f05b46c39bbc0d95f6c071ddff669510fa",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "webmozart/assert": "^1.7.0"
+                "webmozart/assert": "^1.0"
             },
             "replace": {
                 "mtdowling/cron-expression": "^1.0"
             },
             "require-dev": {
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-webmozart-assert": "^0.12.7",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-webmozart-assert": "^1.0",
                 "phpunit/phpunit": "^7.0|^8.0|^9.0"
             },
             "type": "library",
@@ -1207,7 +1025,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dragonmantank/cron-expression/issues",
-                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.1.0"
+                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.3.1"
             },
             "funding": [
                 {
@@ -1215,31 +1033,31 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-24T19:55:57+00:00"
+            "time": "2022-01-18T15:43:28+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.25",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4"
+                "reference": "f88dcf4b14af14a98ad96b14b2b317969eab6715"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/f88dcf4b14af14a98ad96b14b2b317969eab6715",
+                "reference": "f88dcf4b14af14a98ad96b14b2b317969eab6715",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1.0.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.10"
+                "doctrine/lexer": "^1.2",
+                "php": ">=7.2",
+                "symfony/polyfill-intl-idn": "^1.15"
             },
             "require-dev": {
-                "dominicsayers/isemail": "^3.0.7",
-                "phpunit/phpunit": "^4.8.36|^7.5.15",
-                "satooshi/php-coveralls": "^1.0.1"
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5.8|^9.3.3",
+                "vimeo/psalm": "^4"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -1247,7 +1065,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1275,7 +1093,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/2.1.25"
+                "source": "https://github.com/egulias/EmailValidator/tree/3.2.1"
             },
             "funding": [
                 {
@@ -1283,20 +1101,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-29T14:50:06+00:00"
+            "time": "2022-06-18T20:57:19+00:00"
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.17.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "b85e9d44eae8c52cca7aa0939483611f7232b669"
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/b85e9d44eae8c52cca7aa0939483611f7232b669",
-                "reference": "b85e9d44eae8c52cca7aa0939483611f7232b669",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75",
                 "shasum": ""
             },
             "require": {
@@ -1309,10 +1127,12 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
                 "ext-intl": "*",
                 "symfony/phpunit-bridge": "^4.4 || ^5.2"
             },
             "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
                 "ext-curl": "Required by Faker\\Provider\\Image to download images.",
                 "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
                 "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
@@ -1321,7 +1141,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v1.17-dev"
+                    "dev-main": "v1.19-dev"
                 }
             },
             "autoload": {
@@ -1346,9 +1166,80 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.17.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.19.0"
             },
-            "time": "2021-12-05T17:14:47+00:00"
+            "time": "2022-02-02T17:38:57+00:00"
+        },
+        {
+            "name": "fruitcake/php-cors",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/php-cors.git",
+                "reference": "58571acbaa5f9f462c9c77e911700ac66f446d4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/58571acbaa5f9f462c9c77e911700ac66f446d4e",
+                "reference": "58571acbaa5f9f462c9c77e911700ac66f446d4e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "symfony/http-foundation": "^4.4|^5.4|^6"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fruitcake\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barryvdh",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library for the Symfony HttpFoundation",
+            "homepage": "https://github.com/fruitcake/php-cors",
+            "keywords": [
+                "cors",
+                "laravel",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/php-cors/issues",
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-20T15:07:15+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -1464,119 +1355,56 @@
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
-            "name": "hassankhan/config",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hassankhan/config.git",
-                "reference": "62b0fd17540136efa94ab6b39f04044c6dc5e4a7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hassankhan/config/zipball/62b0fd17540136efa94ab6b39f04044c6dc5e4a7",
-                "reference": "62b0fd17540136efa94ab6b39f04044c6dc5e4a7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.5 || ~7.5",
-                "scrutinizer/ocular": "~1.1",
-                "squizlabs/php_codesniffer": "~2.2",
-                "symfony/yaml": "~3.4"
-            },
-            "suggest": {
-                "symfony/yaml": "~3.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Noodlehaus\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Hassan Khan",
-                    "homepage": "http://hassankhan.me/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Lightweight configuration file loader that supports PHP, INI, XML, JSON, and YAML files",
-            "homepage": "http://hassankhan.me/config/",
-            "keywords": [
-                "config",
-                "configuration",
-                "ini",
-                "json",
-                "microphp",
-                "unframework",
-                "xml",
-                "yaml",
-                "yml"
-            ],
-            "support": {
-                "issues": "https://github.com/hassankhan/config/issues",
-                "source": "https://github.com/hassankhan/config/tree/2.2.0"
-            },
-            "time": "2020-12-07T16:04:15+00:00"
-        },
-        {
             "name": "laravel/framework",
-            "version": "v8.75.0",
+            "version": "v9.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "0bb91d3176357da232da69762a64b0e0a0988637"
+                "reference": "bbce25bd823133f6a5a724f2d62680b711f1d0df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/0bb91d3176357da232da69762a64b0e0a0988637",
-                "reference": "0bb91d3176357da232da69762a64b0e0a0988637",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/bbce25bd823133f6a5a724f2d62680b711f1d0df",
+                "reference": "bbce25bd823133f6a5a724f2d62680b711f1d0df",
                 "shasum": ""
             },
             "require": {
-                "doctrine/inflector": "^1.4|^2.0",
-                "dragonmantank/cron-expression": "^3.0.2",
-                "egulias/email-validator": "^2.1.10",
-                "ext-json": "*",
+                "doctrine/inflector": "^2.0",
+                "dragonmantank/cron-expression": "^3.1",
+                "egulias/email-validator": "^3.1",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
+                "fruitcake/php-cors": "^1.2",
                 "laravel/serializable-closure": "^1.0",
-                "league/commonmark": "^1.3|^2.0.2",
-                "league/flysystem": "^1.1",
+                "league/commonmark": "^2.2",
+                "league/flysystem": "^3.0.16",
                 "monolog/monolog": "^2.0",
                 "nesbot/carbon": "^2.53.1",
-                "opis/closure": "^3.6",
-                "php": "^7.3|^8.0",
-                "psr/container": "^1.0",
-                "psr/log": "^1.0 || ^2.0",
-                "psr/simple-cache": "^1.0",
+                "php": "^8.0.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
                 "ramsey/uuid": "^4.2.2",
-                "swiftmailer/swiftmailer": "^6.3",
-                "symfony/console": "^5.4",
-                "symfony/error-handler": "^5.4",
-                "symfony/finder": "^5.4",
-                "symfony/http-foundation": "^5.4",
-                "symfony/http-kernel": "^5.4",
-                "symfony/mime": "^5.4",
-                "symfony/process": "^5.4",
-                "symfony/routing": "^5.4",
-                "symfony/var-dumper": "^5.4",
+                "symfony/console": "^6.0",
+                "symfony/error-handler": "^6.0",
+                "symfony/finder": "^6.0",
+                "symfony/http-foundation": "^6.0",
+                "symfony/http-kernel": "^6.0",
+                "symfony/mailer": "^6.0",
+                "symfony/mime": "^6.0",
+                "symfony/process": "^6.0",
+                "symfony/routing": "^6.0",
+                "symfony/var-dumper": "^6.0",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-                "vlucas/phpdotenv": "^5.2",
-                "voku/portable-ascii": "^1.4.8"
+                "vlucas/phpdotenv": "^5.4.1",
+                "voku/portable-ascii": "^2.0"
             },
             "conflict": {
                 "tightenco/collect": "<5.5.33"
             },
             "provide": {
-                "psr/container-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0"
+                "psr/container-implementation": "1.1|2.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0"
             },
             "replace": {
                 "illuminate/auth": "self.version",
@@ -1584,6 +1412,7 @@
                 "illuminate/bus": "self.version",
                 "illuminate/cache": "self.version",
                 "illuminate/collections": "self.version",
+                "illuminate/conditionable": "self.version",
                 "illuminate/config": "self.version",
                 "illuminate/console": "self.version",
                 "illuminate/container": "self.version",
@@ -1614,18 +1443,22 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^3.198.1",
                 "doctrine/dbal": "^2.13.3|^3.1.4",
-                "filp/whoops": "^2.14.3",
-                "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
-                "league/flysystem-cached-adapter": "^1.0",
+                "fakerphp/faker": "^1.9.2",
+                "guzzlehttp/guzzle": "^7.2",
+                "league/flysystem-aws-s3-v3": "^3.0",
+                "league/flysystem-ftp": "^3.0",
+                "league/flysystem-sftp-v3": "^3.0",
                 "mockery/mockery": "^1.4.4",
-                "orchestra/testbench-core": "^6.27",
+                "orchestra/testbench-core": "^7.1",
                 "pda/pheanstalk": "^4.0",
-                "phpunit/phpunit": "^8.5.19|^9.5.8",
-                "predis/predis": "^1.1.9",
-                "symfony/cache": "^5.4"
+                "phpstan/phpstan": "^1.4.7",
+                "phpunit/phpunit": "^9.5.8",
+                "predis/predis": "^1.1.9|^2.0",
+                "symfony/cache": "^6.0"
             },
             "suggest": {
-                "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.198.1).",
+                "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
+                "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.198.1).",
                 "brianium/paratest": "Required to run tests in parallel (^6.0).",
                 "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
                 "ext-bcmath": "Required to use the multiple_of validation rule.",
@@ -1637,27 +1470,29 @@
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
                 "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
-                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.5.5|^7.0.1).",
+                "guzzlehttp/guzzle": "Required to use the HTTP Client and the ping methods on schedules (^7.2).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
-                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
-                "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
-                "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",
+                "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.0).",
+                "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.0).",
                 "mockery/mockery": "Required to use mocking (^1.4.4).",
                 "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^8.5.19|^9.5.8).",
-                "predis/predis": "Required to use the predis connector (^1.1.9).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^9.5.8).",
+                "predis/predis": "Required to use the predis connector (^1.1.9|^2.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0|^7.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^5.4).",
-                "symfony/filesystem": "Required to enable support for relative symbolic links (^5.4).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
-                "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^6.0).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^6.0).",
+                "symfony/http-client": "Required to enable support for the Symfony API mail transports (^6.0).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.0).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.0).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.x-dev"
+                    "dev-master": "9.x-dev"
                 }
             },
             "autoload": {
@@ -1671,7 +1506,8 @@
                     "Illuminate\\": "src/Illuminate/",
                     "Illuminate\\Support\\": [
                         "src/Illuminate/Macroable/",
-                        "src/Illuminate/Collections/"
+                        "src/Illuminate/Collections/",
+                        "src/Illuminate/Conditionable/"
                     ]
                 }
             },
@@ -1695,20 +1531,76 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-12-07T14:55:46+00:00"
+            "time": "2022-06-28T14:33:19+00:00"
         },
         {
-            "name": "laravel/serializable-closure",
-            "version": "v1.0.5",
+            "name": "laravel/legacy-factories",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "25de3be1bca1b17d52ff0dc02b646c667ac7266c"
+                "url": "https://github.com/laravel/legacy-factories.git",
+                "reference": "5edc7e7eb76e7b4b29221f32139bcbf806c8870f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/25de3be1bca1b17d52ff0dc02b646c667ac7266c",
-                "reference": "25de3be1bca1b17d52ff0dc02b646c667ac7266c",
+                "url": "https://api.github.com/repos/laravel/legacy-factories/zipball/5edc7e7eb76e7b4b29221f32139bcbf806c8870f",
+                "reference": "5edc7e7eb76e7b4b29221f32139bcbf806c8870f",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/macroable": "^8.0|^9.0",
+                "php": "^7.3|^8.0",
+                "symfony/finder": "^3.4|^4.0|^5.0|^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Illuminate\\Database\\Eloquent\\LegacyFactoryServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Database\\Eloquent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The legacy version of the Laravel Eloquent factories.",
+            "homepage": "http://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2022-01-13T08:45:08+00:00"
+        },
+        {
+            "name": "laravel/serializable-closure",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/serializable-closure.git",
+                "reference": "09f0e9fb61829f628205b7c94906c28740ff9540"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/09f0e9fb61829f628205b7c94906c28740ff9540",
+                "reference": "09f0e9fb61829f628205b7c94906c28740ff9540",
                 "shasum": ""
             },
             "require": {
@@ -1754,46 +1646,118 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2021-11-30T15:53:04+00:00"
+            "time": "2022-05-16T17:09:47+00:00"
         },
         {
-            "name": "league/commonmark",
-            "version": "1.6.6",
+            "name": "laravie/query-filter",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "c4228d11e30d7493c6836d20872f9582d8ba6dcf"
+                "url": "https://github.com/laravie/query-filter.git",
+                "reference": "2ff38134c77d9c12ebf28a9f4b25beefc0a326ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c4228d11e30d7493c6836d20872f9582d8ba6dcf",
-                "reference": "c4228d11e30d7493c6836d20872f9582d8ba6dcf",
+                "url": "https://api.github.com/repos/laravie/query-filter/zipball/2ff38134c77d9c12ebf28a9f4b25beefc0a326ae",
+                "reference": "2ff38134c77d9c12ebf28a9f4b25beefc0a326ae",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^8.67 || ^9.0",
+                "illuminate/support": "^8.67 || ^9.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "nunomaduro/larastan": "^1.0.1",
+                "orchestra/canvas": "^6.7 || ^7.0",
+                "orchestra/testbench": "^6.22 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravie\\QueryFilter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com"
+                }
+            ],
+            "description": "Database/Eloquent Query Builder filters for Laravel",
+            "support": {
+                "issues": "https://github.com/laravie/query-filter/issues",
+                "source": "https://github.com/laravie/query-filter/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/crynobone",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://liberapay.com/crynobone",
+                    "type": "liberapay"
+                }
+            ],
+            "time": "2021-12-24T00:47:38+00:00"
+        },
+        {
+            "name": "league/commonmark",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/0da1dca5781dd3cfddbe328224d9a7a62571addc",
+                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "scrutinizer/ocular": "1.7.*"
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "cebe/markdown": "~1.0",
-                "commonmark/commonmark.js": "0.29.2",
-                "erusev/parsedown": "~1.0",
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.30.0",
+                "commonmark/commonmark.js": "0.30.0",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
-                "michelf/php-markdown": "~1.4",
-                "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan": "^0.12.90",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
-                "scrutinizer/ocular": "^1.5",
-                "symfony/finder": "^4.2"
+                "michelf/php-markdown": "^1.4",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^0.12.88 || ^1.0.0",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
             },
-            "bin": [
-                "bin/commonmark"
-            ],
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "League\\CommonMark\\": "src"
@@ -1811,7 +1775,7 @@
                     "role": "Lead Developer"
                 }
             ],
-            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and Github-Flavored Markdown (GFM)",
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
             "homepage": "https://commonmark.thephpleague.com",
             "keywords": [
                 "commonmark",
@@ -1825,15 +1789,12 @@
             ],
             "support": {
                 "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
                 "issues": "https://github.com/thephpleague/commonmark/issues",
                 "rss": "https://github.com/thephpleague/commonmark/releases.atom",
                 "source": "https://github.com/thephpleague/commonmark"
             },
             "funding": [
-                {
-                    "url": "https://enjoy.gitstore.app/repositories/thephpleague/commonmark",
-                    "type": "custom"
-                },
                 {
                     "url": "https://www.colinodell.com/sponsor",
                     "type": "custom"
@@ -1847,66 +1808,138 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/colinodell",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-17T17:13:23+00:00"
+            "time": "2022-06-07T21:28:26+00:00"
         },
         {
-            "name": "league/flysystem",
-            "version": "1.1.8",
+            "name": "league/config",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "c995bb0c23c58c9813d081f9523c9b7bb496698e"
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "a9d39eeeb6cc49d10a6e6c36f22c4c1f4a767f3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c995bb0c23c58c9813d081f9523c9b7bb496698e",
-                "reference": "c995bb0c23c58c9813d081f9523c9b7bb496698e",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/a9d39eeeb6cc49d10a6e6c36f22c4c1f4a767f3e",
+                "reference": "a9d39eeeb6cc49d10a6e6c36f22c4c1f4a767f3e",
                 "shasum": ""
             },
             "require": {
-                "ext-fileinfo": "*",
-                "league/mime-type-detection": "^1.3",
-                "php": "^7.2.5 || ^8.0"
-            },
-            "conflict": {
-                "league/flysystem-sftp": "<1.0.6"
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpspec/prophecy": "^1.11.1",
-                "phpunit/phpunit": "^8.5.8"
-            },
-            "suggest": {
-                "ext-ftp": "Allows you to use FTP server storage",
-                "ext-openssl": "Allows you to use FTPS server storage",
-                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-                "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+                "phpstan/phpstan": "^0.12.90",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "1.2-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\": "src/"
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-08-14T12:15:32+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/34a68067b7ae3b836ea5e57e1fc432478372a4f5",
+                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5",
+                "shasum": ""
+            },
+            "require": {
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "symfony/http-client": "<5.2"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5",
+                "async-aws/simple-s3": "^1.0",
+                "aws/aws-sdk-php": "^3.198.1",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "microsoft/azure-storage-blob": "^1.1",
+                "phpseclib/phpseclib": "^2.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^9.5.11",
+                "sabre/dav": "^4.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1916,53 +1949,55 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "description": "File storage abstraction for PHP",
             "keywords": [
-                "Cloud Files",
                 "WebDAV",
-                "abstraction",
                 "aws",
                 "cloud",
-                "copy.com",
-                "dropbox",
-                "file systems",
+                "file",
                 "files",
                 "filesystem",
                 "filesystems",
                 "ftp",
-                "rackspace",
-                "remote",
                 "s3",
                 "sftp",
                 "storage"
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.8"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.1.0"
             },
             "funding": [
                 {
                     "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-11-28T21:50:23+00:00"
+            "time": "2022-06-29T17:29:54+00:00"
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.9.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69"
+                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/aa70e813a6ad3d1558fc927863d47309b4c23e69",
-                "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
+                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
                 "shasum": ""
             },
             "require": {
@@ -1993,7 +2028,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.9.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.11.0"
             },
             "funding": [
                 {
@@ -2005,20 +2040,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-21T11:48:40+00:00"
+            "time": "2022-04-17T13:12:02+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.4.4",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346"
+                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
-                "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
+                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
                 "shasum": ""
             },
             "require": {
@@ -2075,22 +2110,22 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.4.4"
+                "source": "https://github.com/mockery/mockery/tree/1.5.0"
             },
-            "time": "2021-09-13T15:28:59+00:00"
+            "time": "2022-01-20T13:18:17+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "2.3.5",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
+                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9",
-                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5579edf28aee1190a798bfa5be8bc16c563bd524",
+                "reference": "5579edf28aee1190a798bfa5be8bc16c563bd524",
                 "shasum": ""
             },
             "require": {
@@ -2103,18 +2138,23 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "elasticsearch/elasticsearch": "^7",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
                 "graylog2/gelf-php": "^1.4.2",
+                "guzzlehttp/guzzle": "^7.4",
+                "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.3",
-                "phpspec/prophecy": "^1.6.1",
+                "phpspec/prophecy": "^1.15",
                 "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5",
+                "phpunit/phpunit": "^8.5.14",
                 "predis/predis": "^1.1",
-                "rollbar/rollbar": "^1.3",
-                "ruflin/elastica": ">=0.90@dev",
-                "swiftmailer/swiftmailer": "^5.3|^6.0"
+                "rollbar/rollbar": "^1.3 || ^2 || ^3",
+                "ruflin/elastica": "^7",
+                "swiftmailer/swiftmailer": "^5.3|^6.0",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
@@ -2164,7 +2204,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.3.5"
+                "source": "https://github.com/Seldaek/monolog/tree/2.7.0"
             },
             "funding": [
                 {
@@ -2176,41 +2216,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-01T21:08:31+00:00"
+            "time": "2022-06-09T08:59:12+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2226,7 +2267,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -2234,20 +2275,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.55.2",
+            "version": "2.59.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "8c2a18ce3e67c34efc1b29f64fe61304368259a2"
+                "reference": "a9000603ea337c8df16cc41f8b6be95a65f4d0f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/8c2a18ce3e67c34efc1b29f64fe61304368259a2",
-                "reference": "8c2a18ce3e67c34efc1b29f64fe61304368259a2",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/a9000603ea337c8df16cc41f8b6be95a65f4d0f5",
+                "reference": "a9000603ea337c8df16cc41f8b6be95a65f4d0f5",
                 "shasum": ""
             },
             "require": {
@@ -2262,10 +2303,12 @@
                 "doctrine/orm": "^2.7",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
+                "ondrejmirtes/better-reflection": "*",
                 "phpmd/phpmd": "^2.9",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.54",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "phpstan/phpstan": "^0.12.99 || ^1.7.14",
+                "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "bin": [
@@ -2322,28 +2365,179 @@
             },
             "funding": [
                 {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-03T14:59:52+00:00"
+            "time": "2022-06-29T21:43:55+00:00"
         },
         {
-            "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "name": "nette/schema",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "url": "https://github.com/nette/schema.git",
+                "reference": "9a39cef03a5b34c7de64f551538cbba05c2be5df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nette/schema/zipball/9a39cef03a5b34c7de64f551538cbba05c2be5df",
+                "reference": "9a39cef03a5b34c7de64f551538cbba05c2be5df",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.5.7 || ^3.1.5 ||  ^4.0",
+                "php": ">=7.1 <8.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.3 || ^2.4",
+                "phpstan/phpstan-nette": "^0.12",
+                "tracy/tracy": "^2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.2.2"
+            },
+            "time": "2021-10-15T11:40:02+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "0af4e3de4df9f1543534beab255ccf459e7a2c99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/0af4e3de4df9f1543534beab255ccf459e7a2c99",
+                "reference": "0af4e3de4df9f1543534beab255ccf459e7a2c99",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2 <8.2"
+            },
+            "conflict": {
+                "nette/di": "<3.0.6"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v3.2.7"
+            },
+            "time": "2022-01-24T11:29:14+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -2384,44 +2578,51 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
-            "name": "opis/closure",
-            "version": "3.6.2",
+            "name": "orchestra/database",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/opis/closure.git",
-                "reference": "06e2ebd25f2869e54a306dda991f7db58066f7f6"
+                "url": "https://github.com/orchestral/database.git",
+                "reference": "ce0e49a8da7a652e85db2b736b7346c129b13c43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/06e2ebd25f2869e54a306dda991f7db58066f7f6",
-                "reference": "06e2ebd25f2869e54a306dda991f7db58066f7f6",
+                "url": "https://api.github.com/repos/orchestral/database/zipball/ce0e49a8da7a652e85db2b736b7346c129b13c43",
+                "reference": "ce0e49a8da7a652e85db2b736b7346c129b13c43",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0 || ^8.0"
+                "illuminate/contracts": "^9.0",
+                "illuminate/database": "^9.0",
+                "illuminate/support": "^9.0",
+                "laravie/query-filter": "dev-master",
+                "php": "^7.4 || ^8.0"
             },
-            "require-dev": {
-                "jeremeamia/superclosure": "^2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            "suggest": {
+                "laravie/query-filter": "Allow to use whereLike query builder macros with Laravel (dev-master)."
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.6.x-dev"
+                    "dev-master": "7.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Orchestra\\Database\\CachableQueryServiceProvider",
+                        "Orchestra\\Database\\SearchServiceProvider"
+                    ]
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Opis\\Closure\\": "src/"
-                },
-                "files": [
-                    "functions.php"
-                ]
+                    "Orchestra\\Database\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2429,56 +2630,58 @@
             ],
             "authors": [
                 {
-                    "name": "Marius Sarca",
-                    "email": "marius.sarca@gmail.com"
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com",
+                    "homepage": "https://github.com/taylorotwell"
                 },
                 {
-                    "name": "Sorin Sarca",
-                    "email": "sarca_sorin@hotmail.com"
+                    "name": "Mior Muhammad Zaki",
+                    "email": "crynobone@gmail.com",
+                    "homepage": "https://github.com/crynobone"
                 }
             ],
-            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
-            "homepage": "https://opis.io/closure",
+            "description": "Database Component for Orchestra Platform",
             "keywords": [
-                "anonymous functions",
-                "closure",
-                "function",
-                "serializable",
-                "serialization",
-                "serialize"
+                "database",
+                "orchestra-platform",
+                "orchestral"
             ],
             "support": {
-                "issues": "https://github.com/opis/closure/issues",
-                "source": "https://github.com/opis/closure/tree/3.6.2"
+                "issues": "https://github.com/orchestral/kernel/issues",
+                "source": "https://github.com/orchestral/database/tree/master"
             },
-            "time": "2021-04-09T13:42:10+00:00"
+            "time": "2021-04-18T13:37:50+00:00"
         },
         {
             "name": "orchestra/testbench",
-            "version": "v6.23.1",
+            "version": "v7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "c4c1e420ec0fd60ab149aca0ced194911a46b928"
+                "reference": "4c4a7cf0df2d91cdd202aa6f7177a2476ddd8039"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/c4c1e420ec0fd60ab149aca0ced194911a46b928",
-                "reference": "c4c1e420ec0fd60ab149aca0ced194911a46b928",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/4c4a7cf0df2d91cdd202aa6f7177a2476ddd8039",
+                "reference": "4c4a7cf0df2d91cdd202aa6f7177a2476ddd8039",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^8.71",
+                "fakerphp/faker": "^1.9.2",
+                "laravel/framework": "^9.19",
                 "mockery/mockery": "^1.4.4",
-                "orchestra/testbench-core": "^6.27.3",
-                "php": "^7.3 || ^8.0",
-                "phpunit/phpunit": "^8.5.21 || ^9.5.10",
-                "spatie/laravel-ray": "^1.26.2"
+                "orchestra/testbench-core": "^7.6",
+                "php": "^8.0",
+                "phpunit/phpunit": "^9.5.10",
+                "spatie/laravel-ray": "^1.28",
+                "symfony/process": "^6.0",
+                "symfony/yaml": "^6.0",
+                "vlucas/phpdotenv": "^5.4.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2504,7 +2707,7 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v6.23.1"
+                "source": "https://github.com/orchestral/testbench/tree/v7.6.0"
             },
             "funding": [
                 {
@@ -2516,43 +2719,47 @@
                     "type": "liberapay"
                 }
             ],
-            "time": "2021-12-03T22:47:04+00:00"
+            "time": "2022-06-30T09:57:38+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v6.27.3",
+            "version": "v7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "86867f7853e49a8f516951aa4e303230ebce40ac"
+                "reference": "3e4e7ed08c353f2178b0cbce845ca90c3cb28e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/86867f7853e49a8f516951aa4e303230ebce40ac",
-                "reference": "86867f7853e49a8f516951aa4e303230ebce40ac",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/3e4e7ed08c353f2178b0cbce845ca90c3cb28e08",
+                "reference": "3e4e7ed08c353f2178b0cbce845ca90c3cb28e08",
                 "shasum": ""
             },
             "require": {
-                "fakerphp/faker": "^1.9.1",
-                "php": "^7.3 || ^8.0",
-                "symfony/yaml": "^5.0",
-                "vlucas/phpdotenv": "^5.1"
+                "php": "^8.0"
             },
             "require-dev": {
-                "laravel/framework": "^8.71",
-                "laravel/laravel": "8.x-dev",
+                "fakerphp/faker": "^1.9.2",
+                "laravel/framework": "^9.19",
+                "laravel/laravel": "9.x-dev",
                 "mockery/mockery": "^1.4.4",
-                "orchestra/canvas": "^6.1",
-                "phpunit/phpunit": "^8.5.21 || ^9.5.10 || ^10.0",
-                "spatie/laravel-ray": "^1.7.1",
-                "symfony/process": "^5.0"
+                "orchestra/canvas": "^7.0",
+                "phpunit/phpunit": "^9.5.10 || ^10.0",
+                "symfony/process": "^6.0",
+                "symfony/yaml": "^6.0",
+                "vlucas/phpdotenv": "^5.4.1"
             },
             "suggest": {
-                "laravel/framework": "Required for testing (^8.71).",
+                "brianium/paratest": "Allow using parallel tresting (^6.4).",
+                "fakerphp/faker": "Allow using Faker for testing (^1.9.2).",
+                "laravel/framework": "Required for testing (^9.19).",
                 "mockery/mockery": "Allow using Mockery for testing (^1.4.4).",
-                "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^6.0).",
-                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^6.0).",
-                "phpunit/phpunit": "Allow using PHPUnit for testing (^8.5.21|^9.5.10|^10.0)."
+                "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.2).",
+                "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^7.0).",
+                "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^7.0).",
+                "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.10|^10.0).",
+                "symfony/yaml": "Required for CLI Commander (^6.0).",
+                "vlucas/phpdotenv": "Required for CLI Commander (^5.4.1)."
             },
             "bin": [
                 "testbench"
@@ -2560,16 +2767,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Orchestra\\Testbench\\": "src/"
-                },
                 "files": [
                     "src/helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Orchestra\\Testbench\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2606,7 +2813,7 @@
                     "type": "liberapay"
                 }
             ],
-            "time": "2021-12-03T22:38:19+00:00"
+            "time": "2022-06-30T09:52:25+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2670,16 +2877,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -2715,9 +2922,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2831,16 +3038,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.1",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -2875,9 +3082,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2021-10-02T14:08:47+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -2952,16 +3159,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -3013,22 +3220,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
+            "version": "9.2.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -3084,7 +3291,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -3092,7 +3299,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-05T09:12:13+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3337,16 +3544,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.10",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -3362,7 +3569,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -3376,11 +3583,10 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -3397,11 +3603,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3424,11 +3630,11 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -3436,7 +3642,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-25T07:38:51+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -3493,22 +3699,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -3535,9 +3746,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -3591,30 +3802,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3635,31 +3846,31 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "psr/simple-cache",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3674,7 +3885,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -3686,9 +3897,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
             },
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ramsey/collection",
@@ -3771,25 +3982,24 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.2.3",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df"
+                "reference": "8505afd4fea63b81a85d3b7b53ac3cb8dc347c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
-                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8505afd4fea63b81a85d3b7b53ac3cb8dc347c28",
+                "reference": "8505afd4fea63b81a85d3b7b53ac3cb8dc347c28",
                 "shasum": ""
             },
             "require": {
                 "brick/math": "^0.8 || ^0.9",
+                "ext-ctype": "*",
                 "ext-json": "*",
-                "php": "^7.2 || ^8.0",
-                "ramsey/collection": "^1.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-php80": "^1.14"
+                "php": "^8.0",
+                "ramsey/collection": "^1.0"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
@@ -3826,20 +4036,17 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "4.x-dev"
-                },
                 "captainhook": {
                     "force-install": true
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Ramsey\\Uuid\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3853,7 +4060,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.2.3"
+                "source": "https://github.com/ramsey/uuid/tree/4.3.1"
             },
             "funding": [
                 {
@@ -3865,7 +4072,513 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-25T23:10:38+00:00"
+            "time": "2022-03-27T21:42:02+00:00"
+        },
+        {
+            "name": "roave/security-advisories",
+            "version": "dev-latest",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "7a8c86df136ffe6bd7bc4655d15629a87e5bd022"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/7a8c86df136ffe6bd7bc4655d15629a87e5bd022",
+                "reference": "7a8c86df136ffe6bd7bc4655d15629a87e5bd022",
+                "shasum": ""
+            },
+            "conflict": {
+                "3f/pygmentize": "<1.2",
+                "admidio/admidio": "<4.1.9",
+                "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
+                "akaunting/akaunting": "<2.1.13",
+                "alextselegidis/easyappointments": "<=1.4.3",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amazing/media2click": ">=1,<1.3.3",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<1.0.1",
+                "amphp/http-client": ">=4,<4.4",
+                "anchorcms/anchor-cms": "<=0.12.7",
+                "andreapollastri/cipi": "<=3.1.15",
+                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
+                "appwrite/server-ce": "<0.11.1|>=0.12,<0.12.2",
+                "area17/twill": "<1.2.5|>=2,<2.5.3",
+                "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+                "aws/aws-sdk-php": ">=3,<3.2.1",
+                "bagisto/bagisto": "<0.1.5",
+                "barrelstrength/sprout-base-email": "<1.2.7",
+                "barrelstrength/sprout-forms": "<3.9",
+                "barryvdh/laravel-translation-manager": "<0.6.2",
+                "baserproject/basercms": "<4.5.4",
+                "billz/raspap-webgui": "<=2.6.6",
+                "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
+                "bmarshall511/wordpress_zero_spam": "<5.2.13",
+                "bolt/bolt": "<3.7.2",
+                "bolt/core": "<=4.2",
+                "bottelet/flarepoint": "<2.2.1",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "brotkrueml/codehighlight": "<2.7",
+                "brotkrueml/schema": "<1.13.1|>=2,<2.5.1",
+                "brotkrueml/typo3-matomo-integration": "<1.3.2",
+                "buddypress/buddypress": "<7.2.1",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "bytefury/crater": "<6.0.2",
+                "cachethq/cachet": "<2.5.1",
+                "cakephp/cakephp": "<3.10.3|>=4,<4.0.6",
+                "cardgate/magento2": "<2.0.33",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<=2.1.6",
+                "catfan/medoo": "<1.7.5",
+                "centreon/centreon": "<20.10.7",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "codeception/codeception": "<3.1.3|>=4,<4.1.22",
+                "codeigniter/framework": "<=3.0.6",
+                "codeigniter4/framework": "<4.1.9",
+                "codiad/codiad": "<=2.8.4",
+                "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
+                "concrete5/concrete5": "<9",
+                "concrete5/core": "<8.5.8|>=9,<9.1",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
+                "contao/core": ">=2,<3.5.39",
+                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
+                "contao/listing-bundle": ">=4,<4.4.8",
+                "contao/managed-edition": "<=1.5",
+                "craftcms/cms": "<3.7.36",
+                "croogo/croogo": "<3.0.7",
+                "cuyz/valinor": ">=0.5,<0.7",
+                "czproject/git-php": "<4.0.3",
+                "darylldoyle/safe-svg": "<1.9.10",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
+                "directmailteam/direct-mail": "<5.2.4",
+                "doctrine/annotations": ">=1,<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2|>=3,<3.1.4",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<=0.7.1",
+                "doctrine/mongodb-odm": ">=1,<1.0.2",
+                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
+                "dolibarr/dolibarr": "<16|= 12.0.5|>= 3.3.beta1, < 13.0.2",
+                "dompdf/dompdf": "<1.2.1",
+                "drupal/core": ">=7,<7.88|>=8,<9.2.13|>=9.3,<9.3.6",
+                "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
+                "dweeves/magmi": "<=0.7.24",
+                "ecodev/newsletter": "<=4",
+                "ectouch/ectouch": "<=2.7.2",
+                "elefant/cms": "<1.3.13",
+                "elgg/elgg": "<3.3.24|>=4,<4.0.5",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enshrined/svg-sanitize": "<0.15",
+                "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
+                "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.27",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<1.3.19",
+                "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
+                "ezsystems/ezplatform-richtext": ">=2.3,<=2.3.7",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": "<=6.13.8.1|>=7,<7.5.29",
+                "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
+                "ezyang/htmlpurifier": "<4.1.1",
+                "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
+                "facturascripts/facturascripts": "<=2022.8",
+                "feehi/cms": "<=2.1.1",
+                "feehi/feehicms": "<=0.1.3",
+                "fenom/fenom": "<=2.12.1",
+                "filegator/filegator": "<7.8",
+                "firebase/php-jwt": "<2",
+                "flarum/core": ">=1,<=1.0.1",
+                "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
+                "flarum/tags": "<=0.1-beta.13",
+                "fluidtypo3/vhs": "<5.1.1",
+                "fof/upload": "<1.2.3",
+                "fooman/tcpdf": "<6.2.22",
+                "forkcms/forkcms": "<5.11.1",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "francoisjacquet/rosariosis": "<9.1",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "froala/wysiwyg-editor": "<3.2.7",
+                "froxlor/froxlor": "<=0.10.22",
+                "fuel/core": "<1.8.1",
+                "gaoming13/wechat-php-sdk": "<=1.10.2",
+                "genix/cms": "<=1.1.11",
+                "getgrav/grav": "<1.7.33",
+                "getkirby/cms": "<3.5.8",
+                "getkirby/panel": "<2.5.14",
+                "gilacms/gila": "<=1.11.4",
+                "globalpayments/php-sdk": "<2",
+                "google/protobuf": "<3.15",
+                "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+                "gree/jose": "<=2.2",
+                "gregwar/rst": "<1.0.3",
+                "grumpydictator/firefly-iii": "<5.6.5",
+                "guzzlehttp/guzzle": "<6.5.8|>=7,<7.4.5",
+                "guzzlehttp/psr7": "<1.8.4|>=2,<2.1.1",
+                "helloxz/imgurl": "= 2.31|<=2.31",
+                "hillelcoren/invoice-ninja": "<5.3.35",
+                "hjue/justwriting": "<=1",
+                "hov/jobfair": "<1.0.13|>=2,<2.0.2",
+                "hyn/multi-tenant": ">=5.6,<5.7.2",
+                "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4",
+                "ibexa/post-install": "<=1.0.4",
+                "icecoder/icecoder": "<=8.1",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": "<6.20.26|>=7,<7.30.5|>=8,<8.40",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
+                "impresscms/impresscms": "<=1.4.3",
+                "in2code/femanager": "<5.5.1|>=6,<6.3.1",
+                "intelliants/subrion": "<=4.2.1",
+                "ivankristianto/phpwhois": "<=4.3",
+                "jackalope/jackalope-doctrine-dbal": "<1.7.4",
+                "james-heinrich/getid3": "<1.9.21",
+                "joomla/archive": "<1.1.12|>=2,<2.0.1",
+                "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
+                "joomla/filter": "<1.4.4|>=2,<2.0.1",
+                "joomla/input": ">=2,<2.0.2",
+                "joomla/session": "<1.3.1",
+                "jsdecena/laracom": "<2.0.9",
+                "jsmitty12/phpwhois": "<5.1",
+                "kazist/phpwhois": "<=4.2.6",
+                "kevinpapst/kimai2": "<1.16.7",
+                "kitodo/presentation": "<3.1.2",
+                "klaviyo/magento2-extension": ">=1,<3",
+                "krayin/laravel-crm": "<1.2.2",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
+                "laminas/laminas-http": "<2.14.2",
+                "laravel/fortify": "<1.11.1",
+                "laravel/framework": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
+                "laravel/laravel": "<=9.1.8",
+                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+                "latte/latte": "<2.10.8",
+                "lavalite/cms": "<=5.8",
+                "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
+                "league/commonmark": "<0.18.3",
+                "league/flysystem": "<1.1.4|>=2,<2.1.1",
+                "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
+                "librenms/librenms": "<22.4",
+                "limesurvey/limesurvey": "<3.27.19",
+                "livehelperchat/livehelperchat": "<=3.91",
+                "livewire/livewire": ">2.2.4,<2.2.6",
+                "lms/routes": "<2.1.1",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "luyadev/yii-helpers": "<1.2.1",
+                "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
+                "magento/magento1ce": "<1.9.4.3",
+                "magento/magento1ee": ">=1,<1.14.4.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+                "marcwillmann/turn": "<0.3.3",
+                "matyhtf/framework": "<3.0.6",
+                "mautic/core": "<4.3|= 2.13.1",
+                "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+                "microweber/microweber": "<1.3",
+                "miniorange/miniorange-saml": "<1.4.3",
+                "mittwald/typo3_forum": "<1.2.1",
+                "modx/revolution": "<= 2.8.3-pl|<2.8",
+                "mojo42/jirafeau": "<4.4",
+                "monolog/monolog": ">=1.8,<1.12",
+                "moodle/moodle": "<4.0.1",
+                "mustache/mustache": ">=2,<2.14.1",
+                "namshi/jose": "<2.2",
+                "neoan3-apps/template": "<1.1.1",
+                "neorazorx/facturascripts": "<2022.4",
+                "neos/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "neos/form": ">=1.2,<4.3.3|>=5,<5.0.9|>=5.1,<5.1.3",
+                "neos/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.9.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<5.3.10|>=7,<7.0.9|>=7.1,<7.1.7|>=7.2,<7.2.6|>=7.3,<7.3.4|>=8,<8.0.2",
+                "neos/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
+                "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+                "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "nilsteampassnet/teampass": "<=2.1.27.36",
+                "noumo/easyii": "<=0.9",
+                "nukeviet/nukeviet": "<4.5.2",
+                "nystudio107/craft-seomatic": "<3.4.12",
+                "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/backend": "<1.1.2",
+                "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
+                "october/october": ">=1.0.319,<1.0.466|>=2.1,<2.1.12",
+                "october/rain": "<1.0.472|>=1.1,<1.1.2",
+                "october/system": "<1.0.475|>=1.1,<1.1.11|>=2,<2.1.27",
+                "onelogin/php-saml": "<2.10.4",
+                "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
+                "open-web-analytics/open-web-analytics": "<1.7.4",
+                "opencart/opencart": "<=3.0.3.2",
+                "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<19.4.15|>=20,<20.0.13",
+                "orchid/platform": ">=9,<9.4.4",
+                "oro/crm": ">=1.7,<1.7.4|>=3.1,<4.1.17|>=4.2,<4.2.7",
+                "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<4.2.8",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": ">=0,<3",
+                "pagekit/pagekit": "<=1.0.18",
+                "paragonie/random_compat": "<2",
+                "passbolt/passbolt_api": "<2.11",
+                "paypal/merchant-sdk-php": "<3.12",
+                "pear/archive_tar": "<1.4.14",
+                "pear/crypt_gpg": "<1.6.7",
+                "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
+                "personnummer/personnummer": "<3.0.2",
+                "phanan/koel": "<5.1.4",
+                "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
+                "phpmailer/phpmailer": "<6.5",
+                "phpmussel/phpmussel": ">=1,<1.6",
+                "phpmyadmin/phpmyadmin": "<5.1.3",
+                "phpoffice/phpexcel": "<1.8",
+                "phpoffice/phpspreadsheet": "<1.16",
+                "phpseclib/phpseclib": "<2.0.31|>=3,<3.0.7",
+                "phpservermon/phpservermon": "<=3.5.2",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5,<5.6.3",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "pimcore/data-hub": "<1.2.4",
+                "pimcore/pimcore": "<10.4.4",
+                "pocketmine/bedrock-protocol": "<8.0.2",
+                "pocketmine/pocketmine-mp": ">= 4.0.0-BETA5, < 4.4.2|<4.2.10",
+                "pressbooks/pressbooks": "<5.18",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/blockwishlist": ">=2,<2.1.1",
+                "prestashop/contactform": ">1.0.1,<4.3",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/prestashop": ">=1.7,<=1.7.8.2",
+                "prestashop/productcomments": ">=4,<4.2.1",
+                "prestashop/ps_emailsubscription": "<2.6.1",
+                "prestashop/ps_facetedsearch": "<3.4.1",
+                "prestashop/ps_linklist": "<3.1",
+                "privatebin/privatebin": "<1.4",
+                "propel/propel": ">=2-alpha.1,<=2-alpha.7",
+                "propel/propel1": ">=1,<=1.7.1",
+                "pterodactyl/panel": "<1.7",
+                "ptrofimov/beanstalk_console": "<1.7.14",
+                "pusher/pusher-php-server": "<2.2.1",
+                "pwweb/laravel-core": "<=0.3.6-beta",
+                "rainlab/debugbar-plugin": "<3.1",
+                "remdex/livehelperchat": "<3.99",
+                "rmccue/requests": ">=1.6,<1.8",
+                "robrichards/xmlseclibs": "<3.0.4",
+                "rudloff/alltube": "<3.0.3",
+                "s-cart/core": "<6.9",
+                "s-cart/s-cart": "<6.9",
+                "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
+                "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "shopware/core": "<=6.4.9",
+                "shopware/platform": "<=6.4.9",
+                "shopware/production": "<=6.3.5.2",
+                "shopware/shopware": "<5.7.12",
+                "shopware/storefront": "<=6.4.8.1",
+                "shopxo/shopxo": "<2.2.6",
+                "showdoc/showdoc": "<2.10.4",
+                "silverstripe/admin": ">=1,<1.8.1",
+                "silverstripe/assets": ">=1,<1.10.1",
+                "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
+                "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": "<4.10.9",
+                "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2|= 4.0.0-alpha1",
+                "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
+                "silverstripe/silverstripe-omnipay": "<2.5.2|>=3,<3.0.2|>=3.1,<3.1.4|>=3.2,<3.2.1",
+                "silverstripe/subsites": ">=2,<2.1.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<3",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplito/elliptic-php": "<1.0.6",
+                "slim/slim": "<2.6",
+                "smarty/smarty": "<3.1.45|>=4,<4.1.1",
+                "snipe/snipe-it": "<5.4.4|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "socialiteproviders/steam": "<1.1",
+                "spipu/html2pdf": "<5.2.4",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "ssddanbrown/bookstack": "<22.2.3",
+                "statamic/cms": "<3.2.39|>=3.3,<3.3.2",
+                "stormpath/sdk": ">=0,<9.9.99",
+                "studio-42/elfinder": "<2.1.59",
+                "subrion/cms": "<=4.2.1",
+                "sulu/sulu": "= 2.4.0-RC1|<1.6.44|>=2,<2.2.18|>=2.3,<2.3.8",
+                "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": "<1.10.1",
+                "sylius/paypal-plugin": ">=1,<1.2.4|>=1.3,<1.3.1",
+                "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+                "sylius/sylius": "<1.9.10|>=1.10,<1.10.11|>=1.11,<1.11.2",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+                "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfont/process": ">=0,<4",
+                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3|= 6.0.3|= 5.4.3|= 5.3.14",
+                "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5|>=5.2,<5.3.12",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
+                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
+                "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11|>=5.3,<5.3.12",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.3.2",
+                "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
+                "symfony/symfony": ">=2,<3.4.49|>=4,<4.4.35|>=5,<5.3.12|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+                "t3/dce": ">=2.2,<2.6.2",
+                "t3g/svg-sanitizer": "<1.0.3",
+                "tastyigniter/tastyigniter": "<3.3",
+                "tecnickcom/tcpdf": "<6.2.22",
+                "terminal42/contao-tablelookupwizard": "<3.3.5",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1-beta.1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "thinkcmf/thinkcmf": "<=5.1.7",
+                "tinymce/tinymce": "<5.10",
+                "titon/framework": ">=0,<9.9.99",
+                "topthink/framework": "<6.0.12",
+                "topthink/think": "<=6.0.9",
+                "topthink/thinkphp": "<=3.2.3",
+                "tribalsystems/zenario": "<9.2.55826",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "twig/twig": "<1.38|>=2,<2.14.11|>=3,<3.3.8",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.29|>=11,<11.5.11",
+                "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<7.6.57|>=8,<8.7.47|>=9,<9.5.35|>=10,<10.4.29|>=11,<11.5.11",
+                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+                "ua-parser/uap-php": "<3.8",
+                "unisharp/laravel-filemanager": "<=2.3",
+                "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "vanilla/safecurl": "<0.9.2",
+                "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+                "vrana/adminer": "<4.8.1",
+                "wallabag/tcpdf": "<6.2.22",
+                "wanglelecc/laracms": "<=1.0.3",
+                "web-auth/webauthn-framework": ">=3.3,<3.3.4",
+                "webcoast/deferred-image-processing": "<1.0.2",
+                "wikimedia/parsoid": "<0.12.2",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "wp-cli/wp-cli": "<2.5",
+                "wp-graphql/wp-graphql": "<0.3.5",
+                "wpanel/wpanel4-cms": "<=4.3.1",
+                "wwbn/avideo": "<=11.6",
+                "yeswiki/yeswiki": "<4.1",
+                "yetiforce/yetiforce-crm": "<6.4",
+                "yidashi/yii2cmf": "<=2",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": ">=1.1.14,<1.1.15",
+                "yiisoft/yii2": "<2.0.38",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.43",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<2.0.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.8",
+                "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yourls/yourls": "<=1.8.2",
+                "zendesk/zendesk_api_client_php": "<2.2.11",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": "<1.8.4",
+                "zendframework/zend-feed": "<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": "<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<=3",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": ">=2,<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2",
+                "zoujingli/thinkadmin": "<6.0.22"
+            },
+            "default-branch": true,
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "support": {
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-29T23:04:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4233,16 +4946,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.3",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
@@ -4284,7 +4997,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
             },
             "funding": [
                 {
@@ -4292,7 +5005,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:52:38+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4373,16 +5086,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -4425,7 +5138,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -4433,7 +5146,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4724,28 +5437,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4768,7 +5481,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4776,7 +5489,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4895,41 +5608,43 @@
         },
         {
             "name": "spatie/laravel-ray",
-            "version": "1.26.3",
+            "version": "1.29.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ray.git",
-                "reference": "ec971959bc8e513cbfa1163e6af030cdaa5ce7bf"
+                "reference": "97b8ccdb9975e3339069765417990e89474254ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/ec971959bc8e513cbfa1163e6af030cdaa5ce7bf",
-                "reference": "ec971959bc8e513cbfa1163e6af030cdaa5ce7bf",
+                "url": "https://api.github.com/repos/spatie/laravel-ray/zipball/97b8ccdb9975e3339069765417990e89474254ee",
+                "reference": "97b8ccdb9975e3339069765417990e89474254ee",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "illuminate/contracts": "^7.20|^8.19",
-                "illuminate/database": "^7.20|^8.19",
-                "illuminate/queue": "^7.20|^8.19",
-                "illuminate/support": "^7.20|^8.19",
+                "illuminate/contracts": "^7.20|^8.19|^9.0",
+                "illuminate/database": "^7.20|^8.19|^9.0",
+                "illuminate/queue": "^7.20|^8.19|^9.0",
+                "illuminate/support": "^7.20|^8.19|^9.0",
                 "php": "^7.3|^8.0",
                 "spatie/backtrace": "^1.0",
-                "spatie/ray": "^1.27.1",
-                "symfony/stopwatch": "4.2|^5.1",
+                "spatie/ray": "^1.33",
+                "symfony/stopwatch": "4.2|^5.1|^6.0",
                 "zbateson/mail-mime-parser": "^1.3.1|^2.0"
             },
             "require-dev": {
-                "facade/ignition": "^2.5",
                 "guzzlehttp/guzzle": "^7.3",
-                "laravel/framework": "^7.20|^8.19",
-                "orchestra/testbench-core": "^5.0|^6.0",
+                "laravel/framework": "^7.20|^8.19|^9.0",
+                "orchestra/testbench-core": "^5.0|^6.0|^7.0",
                 "phpstan/phpstan": "^0.12.93",
                 "phpunit/phpunit": "^9.3",
                 "spatie/phpunit-snapshot-assertions": "^4.2"
             },
             "type": "library",
             "extra": {
+                "branch-alias": {
+                    "dev-main": "1.29.x-dev"
+                },
                 "laravel": {
                     "providers": [
                         "Spatie\\LaravelRay\\RayServiceProvider"
@@ -4961,7 +5676,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-ray/issues",
-                "source": "https://github.com/spatie/laravel-ray/tree/1.26.3"
+                "source": "https://github.com/spatie/laravel-ray/tree/1.29.7"
             },
             "funding": [
                 {
@@ -4973,24 +5688,24 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-11-22T15:57:41+00:00"
+            "time": "2022-05-27T18:45:58+00:00"
         },
         {
             "name": "spatie/macroable",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/macroable.git",
-                "reference": "7a99549fc001c925714b329220dea680c04bfa48"
+                "reference": "ec2c320f932e730607aff8052c44183cf3ecb072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/macroable/zipball/7a99549fc001c925714b329220dea680c04bfa48",
-                "reference": "7a99549fc001c925714b329220dea680c04bfa48",
+                "url": "https://api.github.com/repos/spatie/macroable/zipball/ec2c320f932e730607aff8052c44183cf3ecb072",
+                "reference": "ec2c320f932e730607aff8052c44183cf3ecb072",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.0|^9.3"
@@ -5021,22 +5736,22 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/macroable/issues",
-                "source": "https://github.com/spatie/macroable/tree/1.0.1"
+                "source": "https://github.com/spatie/macroable/tree/2.0.0"
             },
-            "time": "2020-11-03T10:15:05+00:00"
+            "time": "2021-03-26T22:39:02+00:00"
         },
         {
             "name": "spatie/ray",
-            "version": "1.32.1",
+            "version": "1.34.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/ray.git",
-                "reference": "73baa5d216865480f0c67cac5cb4dedd1a00f4f1"
+                "reference": "2d64ea264eecbdc7ec01e4e8b45978cae80815d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ray/zipball/73baa5d216865480f0c67cac5cb4dedd1a00f4f1",
-                "reference": "73baa5d216865480f0c67cac5cb4dedd1a00f4f1",
+                "url": "https://api.github.com/repos/spatie/ray/zipball/2d64ea264eecbdc7ec01e4e8b45978cae80815d2",
+                "reference": "2d64ea264eecbdc7ec01e4e8b45978cae80815d2",
                 "shasum": ""
             },
             "require": {
@@ -5046,11 +5761,11 @@
                 "ramsey/uuid": "^3.0|^4.1",
                 "spatie/backtrace": "^1.1",
                 "spatie/macroable": "^1.0|^2.0",
-                "symfony/stopwatch": "^4.0|^5.1",
-                "symfony/var-dumper": "^4.2|^5.1"
+                "symfony/stopwatch": "^4.0|^5.1|^6.0",
+                "symfony/var-dumper": "^4.2|^5.1|^6.0"
             },
             "require-dev": {
-                "illuminate/support": "6.x|^8.18",
+                "illuminate/support": "6.x|^8.18|^9.0",
                 "nesbot/carbon": "^2.43",
                 "phpstan/phpstan": "^0.12.92",
                 "phpunit/phpunit": "^9.5",
@@ -5059,12 +5774,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Spatie\\Ray\\": "src"
-                },
                 "files": [
                     "src/helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Spatie\\Ray\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5086,7 +5801,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/ray/issues",
-                "source": "https://github.com/spatie/ray/tree/1.32.1"
+                "source": "https://github.com/spatie/ray/tree/1.34.5"
             },
             "funding": [
                 {
@@ -5098,126 +5813,47 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-11-30T15:52:12+00:00"
-        },
-        {
-            "name": "swiftmailer/swiftmailer",
-            "version": "v6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "shasum": ""
-            },
-            "require": {
-                "egulias/email-validator": "^2.0|^3.1",
-                "php": ">=7.0.0",
-                "symfony/polyfill-iconv": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.4"
-            },
-            "suggest": {
-                "ext-intl": "Needed to support internationalized email addresses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.2-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "lib/swift_required.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Corbyn"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "https://swiftmailer.symfony.com",
-            "keywords": [
-                "email",
-                "mail",
-                "mailer"
-            ],
-            "support": {
-                "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/swiftmailer/swiftmailer",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2021-10-18T15:26:12+00:00"
+            "time": "2022-06-03T12:32:57+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ec3661faca1d110d6c307e124b44f99ac54179e3"
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ec3661faca1d110d6c307e124b44f99ac54179e3",
-                "reference": "ec3661faca1d110d6c307e124b44f99ac54179e3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a86c1c42fbcb69b59768504c7bca1d3767760b7",
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
+                "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -5257,7 +5893,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.0"
+                "source": "https://github.com/symfony/console/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -5273,25 +5909,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T15:30:56+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "44b933f98bb4b5220d10bed9ce5662f8c2d13dcc"
+                "reference": "05c40f02f621609404b8820ff8bc39acb46e19cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/44b933f98bb4b5220d10bed9ce5662f8c2d13dcc",
-                "reference": "44b933f98bb4b5220d10bed9ce5662f8c2d13dcc",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/05c40f02f621609404b8820ff8bc39acb46e19cf",
+                "reference": "05c40f02f621609404b8820ff8bc39acb46e19cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -5323,7 +5958,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.0"
+                "source": "https://github.com/symfony/css-selector/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -5339,31 +5974,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-09T08:06:01+00:00"
+            "time": "2022-02-25T11:15:52+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8433fa3145ac78df88b87a4a539118e950828126"
+                "reference": "d02c662651e5de760bb7d5e94437113309e8f8a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8433fa3145ac78df88b87a4a539118e950828126",
-                "reference": "8433fa3145ac78df88b87a4a539118e950828126",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d02c662651e5de760bb7d5e94437113309e8f8a0",
+                "reference": "d02c662651e5de760bb7d5e94437113309e8f8a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "require-dev": {
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/http-kernel": "^4.4|^5.0|^6.0",
-                "symfony/serializer": "^4.4|^5.0|^6.0"
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -5394,7 +6029,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.4.0"
+                "source": "https://github.com/symfony/error-handler/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -5410,44 +6045,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T15:30:56+00:00"
+            "time": "2022-05-23T10:32:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "27d39ae126352b9fa3be5e196ccf4617897be3eb"
+                "reference": "a0449a7ad7daa0f7c0acd508259f80544ab5a347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/27d39ae126352b9fa3be5e196ccf4617897be3eb",
-                "reference": "27d39ae126352b9fa3be5e196ccf4617897be3eb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a0449a7ad7daa0f7c0acd508259f80544ab5a347",
+                "reference": "a0449a7ad7daa0f7c0acd508259f80544ab5a347",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4"
+                "symfony/dependency-injection": "<5.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -5479,7 +6112,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -5495,24 +6128,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T10:19:22+00:00"
+            "time": "2022-05-05T16:51:07+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "66bea3b09be61613cd3b4043a65a8ec48cfa6d2a"
+                "reference": "02ff5eea2f453731cfbc6bc215e456b781480448"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/66bea3b09be61613cd3b4043a65a8ec48cfa6d2a",
-                "reference": "66bea3b09be61613cd3b4043a65a8ec48cfa6d2a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/02ff5eea2f453731cfbc6bc215e456b781480448",
+                "reference": "02ff5eea2f453731cfbc6bc215e456b781480448",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
             },
             "suggest": {
@@ -5521,7 +6154,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5558,7 +6191,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -5574,26 +6207,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-02-25T11:15:52+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590"
+                "reference": "45b8beb69d6eb3b05a65689ebfd4222326773f8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/d2f29dac98e96a98be467627bd49c2efb1bc2590",
-                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/45b8beb69d6eb3b05a65689ebfd4222326773f8f",
+                "reference": "45b8beb69d6eb3b05a65689ebfd4222326773f8f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5621,7 +6255,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.0"
+                "source": "https://github.com/symfony/finder/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -5637,33 +6271,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-28T15:25:38+00:00"
+            "time": "2022-04-15T08:08:08+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "5ef86ac7927d2de08dc1e26eb91325f9ccbe6309"
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/5ef86ac7927d2de08dc1e26eb91325f9ccbe6309",
-                "reference": "5ef86ac7927d2de08dc1e26eb91325f9ccbe6309",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/86119d294e51afe4d8e07da96b63332bd1f3f52c",
+                "reference": "86119d294e51afe4d8e07da96b63332bd1f3f52c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
                 "predis/predis": "~1.0",
-                "symfony/cache": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/mime": "^4.4|^5.0|^6.0"
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/mime": "To use the file extension guesser"
@@ -5694,7 +6327,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -5710,68 +6343,66 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-28T15:25:38+00:00"
+            "time": "2022-06-19T13:21:48+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "e012f16688bcb151e965473a70d8ebaa8b1d15ea"
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e012f16688bcb151e965473a70d8ebaa8b1d15ea",
-                "reference": "e012f16688bcb151e965473a70d8ebaa8b1d15ea",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8aaede489900dda61aee208557f63bfa1bca0877",
+                "reference": "8aaede489900dda61aee208557f63bfa1bca0877",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/log": "^1|^2",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^5.0|^6.0",
-                "symfony/http-foundation": "^5.3.7|^6.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/error-handler": "^6.1",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "symfony/browser-kit": "<5.4",
-                "symfony/cache": "<5.0",
-                "symfony/config": "<5.0",
-                "symfony/console": "<4.4",
-                "symfony/dependency-injection": "<5.3",
-                "symfony/doctrine-bridge": "<5.0",
-                "symfony/form": "<5.0",
-                "symfony/http-client": "<5.0",
-                "symfony/mailer": "<5.0",
-                "symfony/messenger": "<5.0",
-                "symfony/translation": "<5.0",
-                "symfony/twig-bridge": "<5.0",
-                "symfony/validator": "<5.0",
+                "symfony/cache": "<5.4",
+                "symfony/config": "<6.1",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<6.1",
+                "symfony/doctrine-bridge": "<5.4",
+                "symfony/form": "<5.4",
+                "symfony/http-client": "<5.4",
+                "symfony/mailer": "<5.4",
+                "symfony/messenger": "<5.4",
+                "symfony/translation": "<5.4",
+                "symfony/twig-bridge": "<5.4",
+                "symfony/validator": "<5.4",
                 "twig/twig": "<2.13"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
                 "symfony/browser-kit": "^5.4|^6.0",
-                "symfony/config": "^5.0|^6.0",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/css-selector": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/config": "^6.1",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/css-selector": "^5.4|^6.0",
+                "symfony/dependency-injection": "^6.1",
+                "symfony/dom-crawler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
                 "symfony/http-client-contracts": "^1.1|^2|^3",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/routing": "^4.4|^5.0|^6.0",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0",
-                "symfony/translation": "^4.4|^5.0|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/translation": "^5.4|^6.0",
                 "symfony/translation-contracts": "^1.1|^2|^3",
+                "symfony/uid": "^5.4|^6.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
@@ -5806,7 +6437,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -5822,42 +6453,114 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T16:56:53+00:00"
+            "time": "2022-06-26T17:06:14+00:00"
         },
         {
-            "name": "symfony/mime",
-            "version": "v5.4.0",
+            "name": "symfony/mailer",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/mime.git",
-                "reference": "d4365000217b67c01acff407573906ff91bcfb34"
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "8fa150355115ea09238858ae3cfaf249fd1fd5ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/d4365000217b67c01acff407573906ff91bcfb34",
-                "reference": "d4365000217b67c01acff407573906ff91bcfb34",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/8fa150355115ea09238858ae3cfaf249fd1fd5ed",
+                "reference": "8fa150355115ea09238858ae3cfaf249fd1fd5ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "egulias/email-validator": "^2.1.10|^3",
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<5.4"
+            },
+            "require-dev": {
+                "symfony/http-client-contracts": "^1.1|^2|^3",
+                "symfony/messenger": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v6.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-19T13:21:48+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v6.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "56508865dd883dce3c863af11b3e8053adab30d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/56508865dd883dce3c863af11b3e8053adab30d7",
+                "reference": "56508865dd883dce3c863af11b3e8053adab30d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
                 "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/mailer": "<4.4"
+                "symfony/mailer": "<5.4"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/property-access": "^4.4|^5.1|^6.0",
-                "symfony/property-info": "^4.4|^5.1|^6.0",
-                "symfony/serializer": "^5.2|^6.0"
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5889,7 +6592,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.4.0"
+                "source": "https://github.com/symfony/mime/tree/v6.1.1"
             },
             "funding": [
                 {
@@ -5905,24 +6608,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T10:19:22+00:00"
+            "time": "2022-06-09T12:51:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -5930,7 +6636,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5938,12 +6644,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5968,7 +6674,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5984,24 +6690,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933"
+                "reference": "143f1881e655bebca1312722af8068de235ae5dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933",
-                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/143f1881e655bebca1312722af8068de235ae5dc",
+                "reference": "143f1881e655bebca1312722af8068de235ae5dc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-iconv": "*"
             },
             "suggest": {
                 "ext-iconv": "For best performance"
@@ -6009,7 +6718,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6017,12 +6726,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Iconv\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6048,7 +6757,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6064,20 +6773,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -6089,7 +6798,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6097,12 +6806,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6129,7 +6838,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6145,20 +6854,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
-                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
+                "reference": "59a8d271f00dd0e4c2e518104cc7963f655a1aa8",
                 "shasum": ""
             },
             "require": {
@@ -6172,7 +6881,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6180,12 +6889,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6216,7 +6925,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6232,20 +6941,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -6257,7 +6966,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6265,12 +6974,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -6300,7 +7009,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6316,24 +7025,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -6341,7 +7053,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6349,12 +7061,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6380,7 +7092,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6396,20 +7108,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
                 "shasum": ""
             },
             "require": {
@@ -6418,7 +7130,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6426,12 +7138,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6456,7 +7168,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6472,99 +7184,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:17:38+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -6573,7 +7206,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6581,12 +7214,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -6618,7 +7251,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6634,20 +7267,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-28T13:41:28+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436"
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/e66119f3de95efc359483f810c4c3e6436279436",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
                 "shasum": ""
             },
             "require": {
@@ -6656,7 +7289,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6664,12 +7297,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -6697,7 +7330,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -6713,25 +7346,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-21T13:25:03+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "5be20b3830f726e019162b26223110c8f47cf274"
+                "reference": "318718453c2be58266f1a9e74063d13cb8dd4165"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/5be20b3830f726e019162b26223110c8f47cf274",
-                "reference": "5be20b3830f726e019162b26223110c8f47cf274",
+                "url": "https://api.github.com/repos/symfony/process/zipball/318718453c2be58266f1a9e74063d13cb8dd4165",
+                "reference": "318718453c2be58266f1a9e74063d13cb8dd4165",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -6759,7 +7391,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.0"
+                "source": "https://github.com/symfony/process/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -6775,41 +7407,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-28T15:25:38+00:00"
+            "time": "2022-05-11T12:12:29+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.0",
+            "version": "v6.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "9eeae93c32ca86746e5d38f3679e9569981038b1"
+                "reference": "8f068b792e515b25e26855ac8dc7fe800399f3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/9eeae93c32ca86746e5d38f3679e9569981038b1",
-                "reference": "9eeae93c32ca86746e5d38f3679e9569981038b1",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/8f068b792e515b25e26855ac8dc7fe800399f3e5",
+                "reference": "8f068b792e515b25e26855ac8dc7fe800399f3e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1"
             },
             "conflict": {
                 "doctrine/annotations": "<1.12",
-                "symfony/config": "<5.3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/yaml": "<4.4"
+                "symfony/config": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/yaml": "<5.4"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.12",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.3|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
-                "symfony/yaml": "^4.4|^5.0|^6.0"
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/config": "For using the all-in-one router or any loader",
@@ -6849,7 +7479,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.0"
+                "source": "https://github.com/symfony/routing/tree/v6.1.1"
             },
             "funding": [
                 {
@@ -6865,26 +7495,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T10:19:22+00:00"
+            "time": "2022-06-08T12:21:15+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1"
+                "php": ">=8.1",
+                "psr/container": "^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -6895,7 +7524,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -6905,7 +7534,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6932,7 +7564,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -6948,24 +7580,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:48:04+00:00"
+            "time": "2022-05-30T19:18:58+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "208ef96122bfed82a8f3a61458a07113a08bdcfe"
+                "reference": "77dedae82ce2a26e2e9b481855473fc3b3e4e54d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/208ef96122bfed82a8f3a61458a07113a08bdcfe",
-                "reference": "208ef96122bfed82a8f3a61458a07113a08bdcfe",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/77dedae82ce2a26e2e9b481855473fc3b3e4e54d",
+                "reference": "77dedae82ce2a26e2e9b481855473fc3b3e4e54d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/service-contracts": "^1|^2|^3"
             },
             "type": "library",
@@ -6994,7 +7626,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -7010,47 +7642,46 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T10:19:22+00:00"
+            "time": "2022-02-25T11:15:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d"
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d",
-                "reference": "9ffaaba53c61ba75a3c7a3a779051d1e9ec4fd2d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1903f2879875280c5af944625e8246d81c2f0604",
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": ">=3.0"
+                "symfony/translation-contracts": "<2.0"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -7080,7 +7711,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.0"
+                "source": "https://github.com/symfony/string/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -7096,52 +7727,51 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-24T10:02:00+00:00"
+            "time": "2022-06-26T16:35:04+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "6fe32b10e912a518805bc9eafc2a87145773cf13"
+                "reference": "b254416631615bc6fe49b0a67f18658827288147"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/6fe32b10e912a518805bc9eafc2a87145773cf13",
-                "reference": "6fe32b10e912a518805bc9eafc2a87145773cf13",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b254416631615bc6fe49b0a67f18658827288147",
+                "reference": "b254416631615bc6fe49b0a67f18658827288147",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/translation-contracts": "^2.3"
+                "symfony/translation-contracts": "^2.3|^3.0"
             },
             "conflict": {
-                "symfony/config": "<4.4",
-                "symfony/console": "<5.3",
-                "symfony/dependency-injection": "<5.0",
-                "symfony/http-kernel": "<5.0",
-                "symfony/twig-bundle": "<5.0",
-                "symfony/yaml": "<4.4"
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-kernel": "<5.4",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
             },
             "provide": {
-                "symfony/translation-implementation": "2.3"
+                "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/config": "^5.4|^6.0",
                 "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.0|^6.0",
-                "symfony/finder": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
                 "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
-                "symfony/http-kernel": "^5.0|^6.0",
-                "symfony/intl": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
                 "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^5.4|^6.0",
                 "symfony/service-contracts": "^1.1.2|^2|^3",
-                "symfony/yaml": "^4.4|^5.0|^6.0"
+                "symfony/yaml": "^5.4|^6.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -7177,7 +7807,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.0"
+                "source": "https://github.com/symfony/translation/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -7193,24 +7823,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T15:30:56+00:00"
+            "time": "2022-05-11T12:12:29+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.5.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "d28150f0f44ce854e942b671fc2620a98aae1b1e"
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/d28150f0f44ce854e942b671fc2620a98aae1b1e",
-                "reference": "d28150f0f44ce854e942b671fc2620a98aae1b1e",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/606be0f48e05116baef052f7f3abdb345c8e02cc",
+                "reference": "606be0f48e05116baef052f7f3abdb345c8e02cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": ">=8.1"
             },
             "suggest": {
                 "symfony/translation-implementation": ""
@@ -7218,7 +7848,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.1-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -7228,7 +7858,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7255,7 +7888,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -7271,36 +7904,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-17T14:20:01+00:00"
+            "time": "2022-06-27T17:24:16+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.0",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "89ab66eaef230c9cd1992de2e9a1b26652b127b9"
+                "reference": "98587d939cb783aa04e828e8fa857edaca24c212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89ab66eaef230c9cd1992de2e9a1b26652b127b9",
-                "reference": "89ab66eaef230c9cd1992de2e9a1b26652b127b9",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/98587d939cb783aa04e828e8fa857edaca24c212",
+                "reference": "98587d939cb783aa04e828e8fa857edaca24c212",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.1",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.4.3",
-                "symfony/console": "<4.4"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/uid": "^5.1|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
                 "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
@@ -7344,7 +7976,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.1.0"
             },
             "funding": [
                 {
@@ -7360,32 +7992,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T15:30:56+00:00"
+            "time": "2022-05-21T13:34:40+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "034ccc0994f1ae3f7499fa5b1f2e75d5e7a94efc"
+                "reference": "b01c4e7dc6a51cbf114567af04a19789fd1011fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/034ccc0994f1ae3f7499fa5b1f2e75d5e7a94efc",
-                "reference": "034ccc0994f1ae3f7499fa5b1f2e75d5e7a94efc",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b01c4e7dc6a51cbf114567af04a19789fd1011fe",
+                "reference": "b01c4e7dc6a51cbf114567af04a19789fd1011fe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
+                "symfony/console": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -7419,7 +8050,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.0"
+                "source": "https://github.com/symfony/yaml/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -7435,7 +8066,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-28T15:25:38+00:00"
+            "time": "2022-06-20T12:01:07+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7489,26 +8120,26 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "b43b05cf43c1b6d849478965062b6ef73e223bb5"
+                "reference": "da444caae6aca7a19c0c140f68c6182e337d5b1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/b43b05cf43c1b6d849478965062b6ef73e223bb5",
-                "reference": "b43b05cf43c1b6d849478965062b6ef73e223bb5",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/da444caae6aca7a19c0c140f68c6182e337d5b1c",
+                "reference": "da444caae6aca7a19c0c140f68c6182e337d5b1c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "php": "^5.5 || ^7.0 || ^8.0",
-                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5 || ^8.5.21 || ^9.5.10"
             },
             "type": "library",
             "extra": {
@@ -7536,22 +8167,22 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.3"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.4"
             },
-            "time": "2020-07-13T06:12:54+00:00"
+            "time": "2021-12-08T09:12:39+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.4.0",
+            "version": "v5.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "d4394d044ed69a8f244f3445bcedf8a0d7fe2403"
+                "reference": "264dce589e7ce37a7ba99cb901eed8249fbec92f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/d4394d044ed69a8f244f3445bcedf8a0d7fe2403",
-                "reference": "d4394d044ed69a8f244f3445bcedf8a0d7fe2403",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/264dce589e7ce37a7ba99cb901eed8249fbec92f",
+                "reference": "264dce589e7ce37a7ba99cb901eed8249fbec92f",
                 "shasum": ""
             },
             "require": {
@@ -7589,11 +8220,13 @@
             "authors": [
                 {
                     "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk"
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
                 },
                 {
                     "name": "Vance Lucas",
-                    "email": "vance@vancelucas.com"
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
                 }
             ],
             "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
@@ -7604,7 +8237,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.4.0"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.4.1"
             },
             "funding": [
                 {
@@ -7616,20 +8249,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-10T01:08:39+00:00"
+            "time": "2021-12-12T23:22:04+00:00"
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "80953678b19901e5165c56752d087fc11526017c"
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
-                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743",
                 "shasum": ""
             },
             "require": {
@@ -7666,7 +8299,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/1.5.6"
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.1"
             },
             "funding": [
                 {
@@ -7690,25 +8323,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-12T00:07:28+00:00"
+            "time": "2022-03-08T17:03:00+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
@@ -7746,22 +8379,22 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
-            "time": "2021-03-09T10:59:23+00:00"
+            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "zbateson/mail-mime-parser",
-            "version": "2.1.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zbateson/mail-mime-parser.git",
-                "reference": "0ef2d7de2577ea0a339d34720451c8ba8cd9dbb4"
+                "reference": "24955de7ec352b3258c1d4551efd21202cb8710c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/0ef2d7de2577ea0a339d34720451c8ba8cd9dbb4",
-                "reference": "0ef2d7de2577ea0a339d34720451c8ba8cd9dbb4",
+                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/24955de7ec352b3258c1d4551efd21202cb8710c",
+                "reference": "24955de7ec352b3258c1d4551efd21202cb8710c",
                 "shasum": ""
             },
             "require": {
@@ -7821,20 +8454,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-09T18:24:41+00:00"
+            "time": "2022-02-22T21:35:59+00:00"
         },
         {
             "name": "zbateson/mb-wrapper",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zbateson/mb-wrapper.git",
-                "reference": "bfd45fb3e2a8cf4c496b2c3ebd63b5f815721498"
+                "reference": "5d9d190ef18ce6d424e3ac6f5ebe13901f92b74a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zbateson/mb-wrapper/zipball/bfd45fb3e2a8cf4c496b2c3ebd63b5f815721498",
-                "reference": "bfd45fb3e2a8cf4c496b2c3ebd63b5f815721498",
+                "url": "https://api.github.com/repos/zbateson/mb-wrapper/zipball/5d9d190ef18ce6d424e3ac6f5ebe13901f92b74a",
+                "reference": "5d9d190ef18ce6d424e3ac6f5ebe13901f92b74a",
                 "shasum": ""
             },
             "require": {
@@ -7880,7 +8513,7 @@
             ],
             "support": {
                 "issues": "https://github.com/zbateson/mb-wrapper/issues",
-                "source": "https://github.com/zbateson/mb-wrapper/tree/1.1.1"
+                "source": "https://github.com/zbateson/mb-wrapper/tree/1.1.2"
             },
             "funding": [
                 {
@@ -7888,7 +8521,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-22T21:59:45+00:00"
+            "time": "2022-05-26T15:55:05+00:00"
         },
         {
             "name": "zbateson/stream-decorators",
@@ -7954,13 +8587,15 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "roave/security-advisories": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "~8.0",
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/database/migrations/0000_00_00_000000_create_families_table.php
+++ b/database/migrations/0000_00_00_000000_create_families_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFamiliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('families', function (Blueprint $table) {
+            $table->increments('id')->index();
+            $table->string('surname')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('families');
+    }
+}

--- a/database/migrations/0000_00_00_000000_create_people_table.php
+++ b/database/migrations/0000_00_00_000000_create_people_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('people', function (Blueprint $table) {
+            $table->increments('id')->index();
+            $table->integer('family_id')->nullable();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->integer('age')->nullable();
+            $table->integer('sex')->nullable();
+            $table->string('email')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('people');
+    }
+}

--- a/database/migrations/0000_00_00_000000_create_vehicles_table.php
+++ b/database/migrations/0000_00_00_000000_create_vehicles_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateVehiclesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('vehicles', function (Blueprint $table) {
+            $table->increments('id')->index();
+            $table->integer('family_id')->nullable();
+            $table->integer('year')->nullable();
+            $table->string('model')->nullable();
+            $table->string('make')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('vehicles');
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,8 @@
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         cacheResultFile="/tmp/.sdk-php.phpunit.result.cache"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
     <include>

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
-use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -26,6 +26,8 @@ use Illuminate\Support\Facades\Cache;
  * @method getRequest()
  * @method setRequest(Request $request)
  * @method getResponse()
+ *
+ * @mixin \EthicalJobs\SDK\HttpClient
  */
 class ApiClient
 {
@@ -118,12 +120,12 @@ class ApiClient
     /**
      * Dynamic http verb methods
      *
-     * @param String $name
-     * @param array $arguments
+     * @param string $name
+     * @param array<int|string, mixed> $arguments
      * @return Mixed
      * @throws Exception
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         if (method_exists($this->http, $name)) {
             return $this->http->$name(...$arguments);

--- a/src/Authentication/AccessTokenFetcher.php
+++ b/src/Authentication/AccessTokenFetcher.php
@@ -23,7 +23,7 @@ class AccessTokenFetcher
     /**
      * Http credentials
      *
-     * @var array
+     * @var array{client_id: string, client_secret: string, username: string, password: string}
      */
     protected $credentials = [
         'client_id' => '',
@@ -32,7 +32,11 @@ class AccessTokenFetcher
         'password' => '',
     ];
 
-    public function __construct(Client $client, Array $credentials = [])
+    /**
+     * @param \GuzzleHttp\Client $client
+     * @param array{client_id: string, client_secret: string, username: string, password: string} $credentials
+     */
+    public function __construct(Client $client, array $credentials = [])
     {
         $this->client = $client;
 

--- a/src/Authentication/AccessTokenFetcher.php
+++ b/src/Authentication/AccessTokenFetcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Authentication;
 
 use GuzzleHttp\Client;
@@ -55,7 +57,7 @@ class AccessTokenFetcher
         $response = $this->tokenRequest($route, $json);
 
         if ($response->getStatusCode() > 199 && $response->getStatusCode() < 300) {
-            if ($decoded = json_decode($response->getBody())) {
+            if ($decoded = json_decode((string)$response->getBody())) {
                 return $decoded->access_token ?? '';
             }
         }

--- a/src/Authentication/Authenticator.php
+++ b/src/Authentication/Authenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Authentication;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/Authentication/NullAuthenticator.php
+++ b/src/Authentication/NullAuthenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Authentication;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/Authentication/TokenAuthenticator.php
+++ b/src/Authentication/TokenAuthenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Authentication;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
 /**

--- a/src/Enumerables/AlertFrequency.php
+++ b/src/Enumerables/AlertFrequency.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/Countries.php
+++ b/src/Enumerables/Countries.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/CreditType.php
+++ b/src/Enumerables/CreditType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/Enum.php
+++ b/src/Enumerables/Enum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 use Exception;

--- a/src/Enumerables/Enum.php
+++ b/src/Enumerables/Enum.php
@@ -9,7 +9,7 @@ use ReflectionClass;
 use ReflectionException;
 
 /**
- * Base enumberable class
+ * Base enumeration class
  *
  * @author Andrew McLagan
  */
@@ -18,32 +18,27 @@ abstract class Enum
     /**
      * Return the constants keys
      *
-     * @return array
-     * @throws ReflectionException
+     * @return array<int, string>
      */
-    public static function allKeys()
+    public static function allKeys(): array
     {
-        return array_keys((new ReflectionClass(get_called_class()))->getConstants());
+        return array_keys(static::all());
     }
 
     /**
      * Return the constants values
      *
-     * @return array
-     * @throws ReflectionException
+     * @return array<int, string>
      */
-    public static function allValues()
+    public static function allValues(): array
     {
-        return array_values((new ReflectionClass(get_called_class()))->getConstants());
+        return array_values(static::all());
     }
 
     /**
      * Return a random constant
-     *
-     * @return array $keys
-     * @throws ReflectionException
      */
-    public static function random()
+    public static function random(): string
     {
         return array_rand(static::all());
     }
@@ -51,25 +46,20 @@ abstract class Enum
     /**
      * Return the constants
      *
-     * @return array $keys
-     * @throws ReflectionException
+     * @return array<string, string>
      */
-    public static function all()
+    public static function all(): array
     {
-        return (new ReflectionClass(get_called_class()))->getConstants();
+        return (new ReflectionClass(static::class))->getConstants();
     }
 
     /**
      * Return a value from a key
-     *
-     * @param string $enumKey
-     * @return array $keys
-     * @throws ReflectionException
      */
-    public static function getValue($enumKey = '')
+    public static function getValue(string $enumKey = ''): ?string
     {
-        foreach (self::all() as $key => $value) {
-            if (strtolower($key) == strtolower($enumKey)) {
+        foreach (static::all() as $key => $value) {
+            if (strtolower($key) === strtolower($enumKey)) {
                 return $value;
             }
         }
@@ -79,15 +69,11 @@ abstract class Enum
 
     /**
      * Return a key from a value
-     *
-     * @param string $enumValue
-     * @return array $keys
-     * @throws ReflectionException
      */
-    public static function getKey($enumValue = '')
+    public static function getKey(string $enumValue = ''): ?string
     {
-        foreach (self::all() as $key => $value) {
-            if (strtolower($value) == strtolower($enumValue)) {
+        foreach (static::all() as $key => $value) {
+            if (strtolower($value) === strtolower($enumValue)) {
                 return $key;
             }
         }
@@ -98,20 +84,18 @@ abstract class Enum
     /**
      * Returns the name of the enumerable key
      *
-     * @param $name
-     * @param $arguments
-     * @return array $keys
-     * @throws ReflectionException
+     * @param string $name
+     * @param array<int|string, mixed> $arguments
      * @throws Exception
      */
-    public static function __callStatic($name, $arguments)
+    public static function __callStatic(string $name, array $arguments): string
     {
-        $class = new ReflectionClass(get_called_class());
+        $class = new ReflectionClass(static::class);
 
         if ($class->hasConstant($name)) {
             return $name;
         }
 
-        throw new Exception('Invalid enumerable: ' . $name);
+        throw new Exception('Invalid enumeration key: ' . $name);
     }
 }

--- a/src/Enumerables/EthicalJobs.php
+++ b/src/Enumerables/EthicalJobs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/JobSource.php
+++ b/src/Enumerables/JobSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/JobStatus.php
+++ b/src/Enumerables/JobStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/Enumerables/JobStatus.php
+++ b/src/Enumerables/JobStatus.php
@@ -6,6 +6,13 @@ namespace EthicalJobs\SDK\Enumerables;
 
 /**
  * Job status
+ *
+ * @method static string DRAFT()
+ * @phpstan-method static "DRAFT" DRAFT()
+ * @method static string PENDING()
+ * @phpstan-method static "PENDING" PENDING()
+ * @method static string APPROVED()
+ * @phpstan-method static "APPROVED" APPROVED()
  */
 class JobStatus extends Enum
 {

--- a/src/Enumerables/States.php
+++ b/src/Enumerables/States.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Enumerables;
 
 /**

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
 use EthicalJobs\SDK\Authentication\Authenticator;
@@ -16,51 +18,12 @@ use GuzzleHttp\Psr7\Response;
  */
 class HttpClient
 {
-    /**
-     * Guzzle client
-     *
-     * @var Client
-     */
-    protected $client;
+    protected bool $authenticate = false;
+    protected Request $request;
+    protected Response $response;
 
-    /**
-     * Guzzle client
-     *
-     * @var Authenticator
-     */
-    protected $authenticator;
-
-    /**
-     * Authenticate requests
-     *
-     * @var bool
-     */
-    protected $authenticate = false;
-
-    /**
-     * PSR7 request
-     *
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * PSR7 response
-     *
-     * @var Response
-     */
-    protected $response;
-
-    /**
-     * Object constructor
-     *
-     * @param Client $client
-     * @param Authenticator $auth
-     */
-    public function __construct(Client $client, Authenticator $auth = null)
+    public function __construct(protected Client $client, protected ?Authenticator $authenticator = null)
     {
-        $this->client = $client;
-        $this->authenticator = $auth;
     }
 
     /**
@@ -225,8 +188,9 @@ class HttpClient
      */
     protected function parseResponse(Response $response)
     {
-        if ($response->getStatusCode() > 199 && $response->getStatusCode() < 299) {
-            if ($body = json_decode($response->getBody()->getContents(), 1)) {
+        $status = $response->getStatusCode();
+        if ($status > 199 && $status < 299) {
+            if ($body = json_decode($response->getBody()->getContents(), true)) {
                 return new Collection($body);
             }
         }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -29,9 +29,9 @@ class HttpClient
     /**
      * Set authentication to true
      *
-     * @return HttpClient
+     * @return $this
      */
-    public function authenticate(): HttpClient
+    public function authenticate(): self
     {
         $this->authenticate = true;
 
@@ -43,11 +43,11 @@ class HttpClient
      *
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function get(string $route, $body = [], $headers = [])
+    public function get(string $route, array $body = [], array $headers = [])
     {
         return $this->request('GET', $route, $body, $headers);
     }
@@ -58,11 +58,11 @@ class HttpClient
      * @param string $verb
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function request(string $verb, string $route, $body = [], $headers = []): Collection
+    public function request(string $verb, string $route, array $body = [], array $headers = []): Collection
     {
         $request = $this->createRequest($verb, $route, $body, $headers);
 
@@ -79,10 +79,10 @@ class HttpClient
      * @param string $verb
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Request
      */
-    protected function createRequest(string $verb, string $route, $body = [], $headers = [])
+    protected function createRequest(string $verb, string $route, array $body = [], array $headers = [])
     {
         $url = Router::getRouteUrl($route);
 
@@ -98,12 +98,12 @@ class HttpClient
     }
 
     /**
-     * Merges degfault headers with user defined headers
+     * Merges default headers with user defined headers
      *
-     * @param array $headers
-     * @return array
+     * @param array<string, string> $headers
+     * @return array<string, string>
      */
-    protected function mergeDefaultHeaders(array $headers = [])
+    protected function mergeDefaultHeaders(array $headers = []): array
     {
         return array_merge([
             'Content-Type' => 'application/json',
@@ -181,7 +181,7 @@ class HttpClient
     }
 
     /**
-     * Prases a response and returns a collection or item
+     * Parses a response and returns a collection or item
      *
      * @param Response $response
      * @return Collection
@@ -203,11 +203,11 @@ class HttpClient
      *
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function post(string $route, $body = [], $headers = [])
+    public function post(string $route, array $body = [], array $headers = [])
     {
         return $this->request('POST', $route, $body, $headers);
     }
@@ -217,11 +217,11 @@ class HttpClient
      *
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function put(string $route, $body = [], $headers = [])
+    public function put(string $route, array $body = [], array $headers = [])
     {
         return $this->request('PUT', $route, $body, $headers);
     }
@@ -231,11 +231,11 @@ class HttpClient
      *
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function patch(string $route, $body = [], $headers = [])
+    public function patch(string $route, array $body = [], array $headers = [])
     {
         return $this->request('PATCH', $route, $body, $headers);
     }
@@ -245,11 +245,11 @@ class HttpClient
      *
      * @param string $route
      * @param array $body
-     * @param array $headers
+     * @param array<string, string> $headers
      * @return Collection
      * @throws GuzzleException
      */
-    public function delete(string $route, $body = [], $headers = [])
+    public function delete(string $route, array $body = [], array $headers = [])
     {
         return $this->request('DELETE', $route, $body, $headers);
     }
@@ -259,7 +259,7 @@ class HttpClient
      *
      * @return Request
      */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }
@@ -282,7 +282,7 @@ class HttpClient
      *
      * @return Response
      */
-    public function getResponse()
+    public function getResponse(): Response
     {
         return $this->response;
     }

--- a/src/Laravel/ApiFacade.php
+++ b/src/Laravel/ApiFacade.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Laravel;
 
 use EthicalJobs\SDK\ApiClient;

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Laravel;
 
 use EthicalJobs\SDK\ApiClient;

--- a/src/Mappers/MapperInterface.php
+++ b/src/Mappers/MapperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Mappers;
 
 /**

--- a/src/Mappers/TaxonomyMapper.php
+++ b/src/Mappers/TaxonomyMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Mappers;
 
 use EthicalJobs\SDK\ApiClient;

--- a/src/Repositories/ApiRepository.php
+++ b/src/Repositories/ApiRepository.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Repositories;
 
 use EthicalJobs\SDK\ApiClient;
 use EthicalJobs\SDK\Collection;
-use EthicalJobs\Storage\Contracts;
-use EthicalJobs\Storage\CriteriaCollection;
-use EthicalJobs\Storage\HasCriteria;
+use EthicalJobs\SDK\Storage\Contracts;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\HasCriteria;
 
 /**
  * Api repository

--- a/src/Repositories/JobApiRepository.php
+++ b/src/Repositories/JobApiRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Repositories;
 
 use EthicalJobs\SDK\ApiClient;

--- a/src/Repositories/TaxonomyApiRepository.php
+++ b/src/Repositories/TaxonomyApiRepository.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Repositories;
 
 use EthicalJobs\SDK\ApiClient;
 use EthicalJobs\SDK\Collection;
-use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 use Illuminate\Support\Arr;
 
 /**

--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -28,7 +28,7 @@ class ResourceCollection extends \Illuminate\Support\Collection
     /**
      * Returns api resources
      *
-     * @return array
+     * @return array<string, class-string<\EthicalJobs\SDK\Repositories\ApiRepository>>
      */
     protected static function resources(): array
     {
@@ -41,7 +41,7 @@ class ResourceCollection extends \Illuminate\Support\Collection
     /**
      * Make a resource repository instance
      *
-     * @param string $repository
+     * @param class-string<Repository> $repository
      * @return Repository
      */
     public static function makeResourceRepository(string $repository): Repository

--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
 use EthicalJobs\SDK\Repositories;
-use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 use Illuminate\Support\Facades\App;
 
 /**

--- a/src/ResponseSelector.php
+++ b/src/ResponseSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
 use Illuminate\Support\Arr;

--- a/src/Router.php
+++ b/src/Router.php
@@ -17,7 +17,7 @@ class Router
      * @param string $route
      * @return string
      */
-    public static function getRouteUrl(string $route)
+    public static function getRouteUrl(string $route): string
     {
         $host = env('API_HOST') ?? 'api.ethicaljobs.com.au';
 
@@ -29,10 +29,10 @@ class Router
     /**
      * Sanitizes a route into acceptable format
      *
-     * @param String $route
-     * @return String
+     * @param string $route
+     * @return string
      */
-    protected static function sanitizeRoute($route = '')
+    protected static function sanitizeRoute(string $route = ''): string
     {
         return '/' . ltrim($route, '/');
     }
@@ -40,11 +40,11 @@ class Router
     /**
      * Return route to the resource
      *
-     * @param String $resource
-     * @param String $route
-     * @return String
+     * @param string $resource
+     * @param string $route
+     * @return string
      */
-    public static function getResourceRoute($resource, $route = '')
+    public static function getResourceRoute(string $resource, string $route = ''): string
     {
         return static::sanitizeRoute($resource) . static::sanitizeRoute($route);
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK;
 
 /**

--- a/src/Storage/Contracts/Criteria.php
+++ b/src/Storage/Contracts/Criteria.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
 interface Criteria
 {

--- a/src/Storage/Contracts/Criteria.php
+++ b/src/Storage/Contracts/Criteria.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+interface Criteria
+{
+    /**
+     * Apply criteria to repository query
+     *
+     * @param Repository $repository
+     * @return mixed
+     */
+    public function apply(Repository $repository);
+}

--- a/src/Storage/Contracts/HasCriteria.php
+++ b/src/Storage/Contracts/HasCriteria.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+use EthicalJobs\Storage\CriteriaCollection;
+
+interface HasCriteria
+{
+    /**
+     * Sets the criteria collection
+     *
+     * @param CriteriaCollection $collection
+     * @return $this
+     */
+    public function setCriteriaCollection(CriteriaCollection $collection);
+
+    /**
+     * Gets the criteria collection
+     *
+     * @return CriteriaCollection
+     */
+    public function getCriteriaCollection(): CriteriaCollection;
+
+    /**
+     * Push a new criteria onto the collection
+     *
+     * @param string $criteria
+     * @return $this
+     */
+    public function addCriteria(string $criteria);
+
+    /**
+     * Applies the criterion to the repository query
+     *
+     * @return $this
+     */
+    public function applyCriteria();
+}

--- a/src/Storage/Contracts/HasCriteria.php
+++ b/src/Storage/Contracts/HasCriteria.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
-use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
 
 interface HasCriteria
 {

--- a/src/Storage/Contracts/HydratesResults.php
+++ b/src/Storage/Contracts/HydratesResults.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
 interface HydratesResults
 {

--- a/src/Storage/Contracts/HydratesResults.php
+++ b/src/Storage/Contracts/HydratesResults.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+interface HydratesResults
+{
+    /**
+     * Sets the current hydrator instance
+     *
+     * @param Hydrator $hydrator
+     * @return $this
+     */
+    public function setHydrator(Hydrator $hydrator);
+
+    /**
+     * Returns the current hydrator instance
+     *
+     * @return Hydrator
+     */
+    public function getHydrator(): Hydrator;
+}

--- a/src/Storage/Contracts/Hydrator.php
+++ b/src/Storage/Contracts/Hydrator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+interface Hydrator
+{
+    /**
+     * Hydrates collection of entities
+     *
+     * @param iterable $collection
+     * @return iterable
+     */
+    public function hydrateCollection(iterable $collection): iterable;
+
+    /**
+     * Hydrates single entity
+     *
+     * @param mixed $entity
+     * @return mixed
+     */
+    public function hydrateEntity($entity);
+}

--- a/src/Storage/Contracts/Hydrator.php
+++ b/src/Storage/Contracts/Hydrator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
 interface Hydrator
 {

--- a/src/Storage/Contracts/QueriesByParameters.php
+++ b/src/Storage/Contracts/QueriesByParameters.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
 interface QueriesByParameters
 {

--- a/src/Storage/Contracts/QueriesByParameters.php
+++ b/src/Storage/Contracts/QueriesByParameters.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+interface QueriesByParameters
+{
+    /**
+     * Sets the repository
+     *
+     * @param Repository $repository
+     * @return QueriesByParameters
+     */
+    public function setRepository(Repository $repository): QueriesByParameters;
+
+    /**
+     * Returns the repository
+     *
+     * @return Repository
+     */
+    public function getRepository(): Repository;
+
+    /**
+     * Returns results from the parameter query
+     *
+     * @param array $parameters
+     * @return iterable
+     */
+    public function find(array $parameters): iterable;
+}

--- a/src/Storage/Contracts/Repository.php
+++ b/src/Storage/Contracts/Repository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EthicalJobs\Storage\Contracts;
+namespace EthicalJobs\SDK\Storage\Contracts;
 
 interface Repository
 {

--- a/src/Storage/Contracts/Repository.php
+++ b/src/Storage/Contracts/Repository.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace EthicalJobs\Storage\Contracts;
+
+interface Repository
+{
+    /**
+     * Get the current storage engine instance
+     *
+     * @return mixed
+     */
+    public function getStorageEngine();
+
+    /**
+     * Sets the current storage engine instance
+     *
+     * @param mixed $storage
+     * @return $this
+     */
+    public function setStorageEngine($storage);
+
+    /**
+     * Find a model by its id
+     *
+     * @param string|int $id
+     * @return mixed
+     */
+    public function findById($id);
+
+    /**
+     * Find a model by a field
+     *
+     * @param string $field
+     * @param mixed $value
+     * @return mixed
+     */
+    public function findByField(string $field, $value);
+
+    /**
+     * Executes a where query on a field.
+     * - As a shortcut $operator can be $value for an assumed = operator
+     * - Valid operators [>=, <=, >, <, !=, like]
+     *
+     * @param string $field
+     * @param mixed $operator
+     * @param mixed $value
+     * @return $this
+     */
+    public function where(string $field, $operator, $value = null): Repository;
+
+    /**
+     * Executes a whereIn query matching an array of values.
+     *
+     * @param string $field
+     * @param array $values
+     * @return $this
+     */
+    public function whereIn(string $field, array $values): Repository;
+
+    /**
+     * Executes a whereHasIn query matching an array of values on a related field
+     *
+     * @param string $field
+     * @param array $values
+     * @return $this
+     */
+    public function whereHasIn(string $field, array $values): Repository;
+
+    /**
+     * Execute an order by query
+     *
+     * @param string $field
+     * @param string $direction
+     * @return $this
+     */
+    public function orderBy(string $field, string $direction): Repository;
+
+    /**
+     * Limit the current query
+     *
+     * @param int $limit
+     * @return $this
+     */
+    public function limit(int $limit): Repository;
+
+    /**
+     * Add key-word search to query
+     *
+     * @param string $term
+     * @return $this
+     */
+    public function search(string $term = ''): Repository;
+
+    /**
+     * Return the result of the query
+     *
+     * @return iterable
+     */
+    public function find(): iterable;
+
+    /**
+     * Update a entity by id
+     *
+     * @param mixed $id
+     * @param array $attributes
+     * @return mixed
+     */
+    public function update($id, array $attributes);
+
+    /**
+     * Update collection of entities
+     *
+     * @param iterable $entities
+     * @return mixed
+     */
+    public function updateCollection(iterable $entities);
+
+    /**
+     * Delete an entity by id
+     *
+     * @param mixed $id
+     * @return mixed
+     */
+    public function delete($id);
+}

--- a/src/Storage/CriteriaCollection.php
+++ b/src/Storage/CriteriaCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EthicalJobs\SDK\Storage;
+
+class CriteriaCollection extends LegacyCollection
+{
+    /**
+     * Push a criteria class
+     *
+     * Unclear what the purpose of this is, why it doesn't push but instead puts or why it was made a dependency.
+     *
+     * @TODO Remove dependency on this and potentially entire package
+     *
+     * @param  mixed  $values [optional]
+     * @return $this
+     */
+    public function push(...$values)
+    {
+        foreach ($values as $value) {
+            $instance = new $value;
+
+            $this->put($value, $instance);
+        }
+
+        return $this;
+    }
+}

--- a/src/Storage/DatabaseRepository.php
+++ b/src/Storage/DatabaseRepository.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace EthicalJobs\Storage;
+namespace EthicalJobs\SDK\Storage;
 
-use EthicalJobs\Storage\Contracts;
-use EthicalJobs\Storage\HasCriteria;
+use EthicalJobs\SDK\Storage\Contracts;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -13,25 +12,10 @@ abstract class DatabaseRepository implements Contracts\Repository, Contracts\Has
 {
     use HasCriteria;
 
-    /**
-     * Eloquent model
-     *
-     * @var Model
-     */
-    protected $model;
+    protected Model $model;
 
-    /**
-     * Eloquent model query builder
-     *
-     * @var Builder
-     */
-    protected $query;
+    protected Builder $query;
 
-    /**
-     * Object constructor
-     *
-     * @param Model $model
-     */
     public function __construct(Model $model)
     {
         $this->model = $model;
@@ -64,7 +48,7 @@ abstract class DatabaseRepository implements Contracts\Repository, Contracts\Has
      */
     public function findByField(string $field, $value)
     {
-        $results = $this->model->where($field, '=', $value)->get();
+        $results = $this->model->newQuery()->where($field, '=', $value)->get();
 
         if ($results->isNotEmpty()) {
             return $results->first();
@@ -191,7 +175,7 @@ abstract class DatabaseRepository implements Contracts\Repository, Contracts\Has
             return $id;
         }
 
-        if ($entity = $this->model->find($id)) {
+        if ($entity = $this->model->newQuery()->find($id)) {
             return $entity;
         }
 

--- a/src/Storage/DatabaseRepository.php
+++ b/src/Storage/DatabaseRepository.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace EthicalJobs\Storage;
+
+use EthicalJobs\Storage\Contracts;
+use EthicalJobs\Storage\HasCriteria;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+abstract class DatabaseRepository implements Contracts\Repository, Contracts\HasCriteria
+{
+    use HasCriteria;
+
+    /**
+     * Eloquent model
+     *
+     * @var Model
+     */
+    protected $model;
+
+    /**
+     * Eloquent model query builder
+     *
+     * @var Builder
+     */
+    protected $query;
+
+    /**
+     * Object constructor
+     *
+     * @param Model $model
+     */
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+
+        $this->setStorageEngine($model->query());
+
+        $this->criteria = new CriteriaCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStorageEngine($storage)
+    {
+        $this->query = $storage;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStorageEngine()
+    {
+        return $this->query;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findByField(string $field, $value)
+    {
+        $results = $this->model->where($field, '=', $value)->get();
+
+        if ($results->isNotEmpty()) {
+            return $results->first();
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function where(string $field, $operator, $value = null): Contracts\Repository
+    {
+        $this->query->where($field, $operator, $value);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function whereIn(string $field, array $values): Contracts\Repository
+    {
+        $this->query->whereIn($field, $values);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function whereHasIn(string $relation, array $values): Contracts\Repository
+    {
+        $fields = explode('.', $relation);
+
+        $this->query->whereHas($fields[0], function ($query) use ($relation, $values) {
+            $query->whereIn(Str::snake($relation), $values);
+        });
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function orderBy(string $field, string $direction): Contracts\Repository
+    {
+        $this->query->orderBy($field, $direction);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function limit(int $limit): Contracts\Repository
+    {
+        $this->query->limit($limit);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function search(string $term = ''): Contracts\Repository
+    {
+        // must be implemented by child
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find(): iterable
+    {
+        $this->applyCriteria();
+
+        return $this->query->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateCollection(iterable $entities)
+    {
+        if (!$entities instanceof Collection) {
+            $entities = new Collection($entities);
+        }
+
+        $updatedEntities = new Collection;
+
+        foreach ($entities as $id => $entity) {
+
+            $updated = $this->update($id, $entity);
+
+            $updatedEntities->push($updated);
+        }
+
+        return $updatedEntities;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($id, array $attributes)
+    {
+        $entity = $this->findById($id);
+
+        $entity->fill($attributes);
+
+        $entity->save();
+
+        return $entity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findById($id)
+    {
+        if ($id instanceof Model) {
+            return $id;
+        }
+
+        if ($entity = $this->model->find($id)) {
+            return $entity;
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($id)
+    {
+        $entity = $this->findById($id);
+
+        $entity->delete();
+
+        return $entity;
+    }
+}

--- a/src/Storage/HasCriteria.php
+++ b/src/Storage/HasCriteria.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EthicalJobs\SDK\Storage;
+
+trait HasCriteria
+{
+    protected $criteria;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCriteriaCollection(CriteriaCollection $collection)
+    {
+        $this->criteria = $collection;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCriteriaCollection(): CriteriaCollection
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCriteria(string $criteria)
+    {
+        $this->criteria->push($criteria);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyCriteria()
+    {
+        foreach ($this->criteria as $criteria) {
+            $criteria->apply($this);
+        }
+
+        return $this;
+    }
+}

--- a/src/Storage/HydratesResults.php
+++ b/src/Storage/HydratesResults.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EthicalJobs\Storage;
+
+use EthicalJobs\Storage\Contracts\Hydrator;
+
+trait HydratesResults
+{
+    /**
+     * Hydrator instance
+     *
+     * @var Hydrator
+     */
+    protected $hydrator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHydrator(): Hydrator
+    {
+        return $this->hydrator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setHydrator(Hydrator $hydrator)
+    {
+        $this->hydrator = $hydrator;
+
+        return $this;
+    }
+}

--- a/src/Storage/HydratesResults.php
+++ b/src/Storage/HydratesResults.php
@@ -1,29 +1,18 @@
 <?php
 
-namespace EthicalJobs\Storage;
+namespace EthicalJobs\SDK\Storage;
 
-use EthicalJobs\Storage\Contracts\Hydrator;
+use EthicalJobs\SDK\Storage\Contracts\Hydrator;
 
 trait HydratesResults
 {
-    /**
-     * Hydrator instance
-     *
-     * @var Hydrator
-     */
-    protected $hydrator;
+    protected Hydrator $hydrator;
 
-    /**
-     * {@inheritdoc}
-     */
     public function getHydrator(): Hydrator
     {
         return $this->hydrator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setHydrator(Hydrator $hydrator)
     {
         $this->hydrator = $hydrator;

--- a/src/Storage/LegacyCollection.php
+++ b/src/Storage/LegacyCollection.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/src/Storage/LegacyCollection.php
+++ b/src/Storage/LegacyCollection.php
@@ -1,3 +1,61 @@
 <?php
 
 declare(strict_types=1);
+
+namespace EthicalJobs\SDK\Storage;
+
+use Illuminate\Support\Collection as LaravelCollection;
+
+class LegacyCollection extends LaravelCollection
+{
+    public function __construct($items = [])
+    {
+        if (count($items)) {
+            parent::__construct($items);
+        } else {
+            parent::__construct(static::items());
+        }
+    }
+
+    /**
+     * Create a new collection.
+     *
+     */
+    public static function items()
+    {
+        return [];
+    }
+
+
+    public static function instances(): LaravelCollection
+    {
+        $instances = new LaravelCollection;
+
+        foreach (static::make()->all() as $key => $value) {
+            if ($instance = self::instance($key)) {
+                $instances->put($key, $instance);
+            }
+        }
+
+        return $instances;
+    }
+
+    /**
+     * Create an instance of a collection item
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public static function instance(string $key)
+    {
+        $collection = static::make();
+
+        $class = $collection->get($key) ?? '';
+
+        if (class_exists($class)) {
+            return resolve($class);
+        }
+
+        return null;
+    }
+}

--- a/src/Storage/ParameterQuery.php
+++ b/src/Storage/ParameterQuery.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace EthicalJobs\Storage;
+
+use Carbon\Carbon;
+use EthicalJobs\Storage\Contracts\QueriesByParameters;
+use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\Utilities\Timestamp;
+use Illuminate\Support\Str;
+
+abstract class ParameterQuery implements QueriesByParameters
+{
+    /**
+     * Repository instance
+     *
+     * @var Repository
+     */
+    protected $repository;
+
+    /**
+     * Object constructor
+     *
+     * @return void
+     * @var Repository $repository
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->setRepository($repository);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find(array $parameters): iterable
+    {
+        foreach ($parameters as $parameter => $value) {
+
+            $snakeCased = Str::snake($parameter);
+
+            if (method_exists($this, $parameter)) {
+                $this->$parameter($value);
+            } else {
+                if (method_exists($this, $snakeCased)) {
+                    $this->$snakeCased($value);
+                }
+            }
+        }
+
+        return $this->repository->find();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository(): Repository
+    {
+        return $this->repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRepository(Repository $repository): QueriesByParameters
+    {
+        $this->repository = $repository;
+
+        return $this;
+    }
+
+    /**
+     * Filter by search term
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function q($value)
+    {
+        $this->repository->search((string)$value);
+    }
+
+    /**
+     * Order by field
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function orderBy($value)
+    {
+        $this->repository->orderBy($value, 'asc');
+    }
+
+    /**
+     * Limit query
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function limit($value)
+    {
+        $this->repository->limit($value);
+    }
+
+    /**
+     * Filter by dateFrom
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function dateFrom($value)
+    {
+        $this->repository->where('created_at', '>=', Carbon::parse($value));
+    }
+
+    /**
+     * Filter by dateTo
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function dateTo($value)
+    {
+        $this->repository->where('created_at', '<=', Carbon::parse($value));
+    }
+}

--- a/src/Storage/ParameterQuery.php
+++ b/src/Storage/ParameterQuery.php
@@ -1,21 +1,15 @@
 <?php
 
-namespace EthicalJobs\Storage;
+namespace EthicalJobs\SDK\Storage;
 
 use Carbon\Carbon;
-use EthicalJobs\Storage\Contracts\QueriesByParameters;
-use EthicalJobs\Storage\Contracts\Repository;
-use EthicalJobs\Utilities\Timestamp;
+use EthicalJobs\SDK\Storage\Contracts\QueriesByParameters;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 use Illuminate\Support\Str;
 
 abstract class ParameterQuery implements QueriesByParameters
 {
-    /**
-     * Repository instance
-     *
-     * @var Repository
-     */
-    protected $repository;
+    protected Repository $repository;
 
     /**
      * Object constructor
@@ -39,10 +33,8 @@ abstract class ParameterQuery implements QueriesByParameters
 
             if (method_exists($this, $parameter)) {
                 $this->$parameter($value);
-            } else {
-                if (method_exists($this, $snakeCased)) {
-                    $this->$snakeCased($value);
-                }
+            } elseif (method_exists($this, $snakeCased)) {
+                $this->$snakeCased($value);
             }
         }
 

--- a/src/Testing/RequestFactory.php
+++ b/src/Testing/RequestFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Testing;
 
 use Illuminate\Http\Request;

--- a/src/Testing/ResourceFactory.php
+++ b/src/Testing/ResourceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Testing;
 
 use EthicalJobs\SDK\Collection;

--- a/src/Testing/ResponseFactory.php
+++ b/src/Testing/ResponseFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\SDK\Testing;
 
 use EthicalJobs\SDK\Collection;
@@ -122,7 +124,7 @@ class ResponseFactory
      */
     public static function response(int $status, $data): Response
     {
-        $encoded = json_encode($data, true);
+        $encoded = json_encode($data);
 
         $stream = Psr7Utils::streamFor($encoded);
 

--- a/tests/EndToEnd/ApiClientFetchTest.php
+++ b/tests/EndToEnd/ApiClientFetchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\EndToEnd;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Fixtures/Collections/BackWardsCompatible.php
+++ b/tests/Fixtures/Collections/BackWardsCompatible.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Fixtures\Collections;
+
+use EthicalJobs\Storage\Collection;
+use Tests\Fixtures\Models;
+
+class BackWardsCompatible extends Collection
+{
+    /**
+     * Create a new collection.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct([
+            'families' => Models\Family::class,
+            'people' => Models\Person::class,
+            'vehicles' => Models\Vehicle::class,
+        ]);
+    }
+}

--- a/tests/Fixtures/Collections/BackWardsCompatible.php
+++ b/tests/Fixtures/Collections/BackWardsCompatible.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Fixtures\Collections;
 
-use EthicalJobs\Storage\Collection;
+use EthicalJobs\SDK\Storage\LegacyCollection;
 use Tests\Fixtures\Models;
 
-class BackWardsCompatible extends Collection
+class BackWardsCompatible extends LegacyCollection
 {
     /**
      * Create a new collection.

--- a/tests/Fixtures/Collections/ModelsCollection.php
+++ b/tests/Fixtures/Collections/ModelsCollection.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Fixtures\Collections;
 
-use EthicalJobs\Storage\Collection;
+use EthicalJobs\SDK\Storage\LegacyCollection;
 use Tests\Fixtures\Models;
 
-class ModelsCollection extends Collection
+class ModelsCollection extends LegacyCollection
 {
     /**
      * Create a new collection.

--- a/tests/Fixtures/Collections/ModelsCollection.php
+++ b/tests/Fixtures/Collections/ModelsCollection.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Fixtures\Collections;
+
+use EthicalJobs\Storage\Collection;
+use Tests\Fixtures\Models;
+
+class ModelsCollection extends Collection
+{
+    /**
+     * Create a new collection.
+     *
+     * @return array
+     */
+    public static function items()
+    {
+        return [
+            'families' => Models\Family::class,
+            'people' => Models\Person::class,
+            'vehicles' => Models\Vehicle::class,
+        ];
+    }
+}

--- a/tests/Fixtures/Criteria/Males.php
+++ b/tests/Fixtures/Criteria/Males.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Fixtures\Criteria;
 
-use EthicalJobs\Storage\Contracts\Criteria;
-use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\Contracts\Criteria;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 
 class Males implements Criteria
 {

--- a/tests/Fixtures/Criteria/Males.php
+++ b/tests/Fixtures/Criteria/Males.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Fixtures\Criteria;
+
+use EthicalJobs\Storage\Contracts\Criteria;
+use EthicalJobs\Storage\Contracts\Repository;
+
+class Males implements Criteria
+{
+    public function apply(Repository $repository)
+    {
+        $repository
+            ->where('sex', '=', 'male');
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Criteria/OverFifty.php
+++ b/tests/Fixtures/Criteria/OverFifty.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Fixtures\Criteria;
+
+use EthicalJobs\Storage\Contracts\Criteria;
+use EthicalJobs\Storage\Contracts\Repository;
+
+class OverFifty implements Criteria
+{
+    public function apply(Repository $repository)
+    {
+        $repository
+            ->where('age', '>', 50);
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Criteria/OverFifty.php
+++ b/tests/Fixtures/Criteria/OverFifty.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Fixtures\Criteria;
 
-use EthicalJobs\Storage\Contracts\Criteria;
-use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\Contracts\Criteria;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
 
 class OverFifty implements Criteria
 {

--- a/tests/Fixtures/ModelMock.php
+++ b/tests/Fixtures/ModelMock.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Faker\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Tests\Fixtures\Models\Family;
+use Tests\Fixtures\Models\Person;
+use Tests\Fixtures\Models\Vehicle;
+
+class ModelMock
+{
+    /** @var \Illuminate\Database\Eloquent\Model */
+    private $model;
+
+    /** @var \Faker\Generator */
+    private $faker;
+
+    public function __construct(string $model)
+    {
+        $this->model = new $model;
+        $this->faker = Factory::create();
+    }
+
+    public function create(?array $data = []): Model
+    {
+        $data = array_merge($this->getDefaults(), $data);
+
+        $this->model->forceFill($data);
+
+        $this->model->save();
+
+        return $this->model;
+    }
+
+    private function getDefaults(): array
+    {
+        $data = [];
+
+        switch (get_class($this->model)) {
+            case Family::class:
+                $data = [
+                    'surname' => $this->faker->name,
+                ];
+                break;
+            case Person::class:
+                $data = [
+                    'first_name' => $this->faker->firstName,
+                    'last_name' => $this->faker->lastName,
+                    'email' => $this->faker->email,
+                    'sex' => $this->faker->randomElement(['female', 'male']),
+                    'deleted_at' => null,
+                ];
+                break;
+            case Vehicle::class:
+                $data = [
+                    'year' => $this->faker->numberBetween(1990,2030),
+                    'make' => $this->faker->company,
+                    'model' => $this->faker->word,
+                ];
+                break;
+        }
+
+        return $data;
+    }
+}

--- a/tests/Fixtures/ModelMock.php
+++ b/tests/Fixtures/ModelMock.php
@@ -30,7 +30,6 @@ class ModelMock
         $this->model->forceFill($data);
 
         $this->model->save();
-
         return $this->model;
     }
 

--- a/tests/Fixtures/Models/Family.php
+++ b/tests/Fixtures/Models/Family.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Family extends Model
+{
+    public function vehicles()
+    {
+        return $this->hasOne(Vehicle::class);
+    }
+
+    public function people()
+    {
+        return $this->hasMany(Person::class);
+    }
+}

--- a/tests/Fixtures/Models/Person.php
+++ b/tests/Fixtures/Models/Person.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Person extends Model
+{
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'age',
+        'email',
+    ];
+
+    public function family()
+    {
+        return $this->belongsTo(Family::class);
+    }
+}

--- a/tests/Fixtures/Models/Vehicle.php
+++ b/tests/Fixtures/Models/Vehicle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Vehicle extends Model
+{
+    public function family()
+    {
+        return $this->belongsTo(Family::class);
+    }
+}

--- a/tests/Fixtures/ParameterQueries/PersonParameterQuery.php
+++ b/tests/Fixtures/ParameterQueries/PersonParameterQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Fixtures\ParameterQueries;
+
+use EthicalJobs\Storage\ParameterQuery;
+
+class PersonParameterQuery extends ParameterQuery
+{
+    /**
+     * Available parameters
+     *
+     * @var array
+     */
+    protected $parameters = [
+        'ages',
+        'last_name',
+        'email',
+    ];
+
+    /**
+     * [ages] filter by ages
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function ages($value)
+    {
+        $value = is_array($value) ? $value : [$value];
+
+        $this->repository->whereIn('age', $value);
+    }
+
+    /**
+     * [last_name] filter by last name
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function last_name($value)
+    {
+        $this->repository->where('last_name', '=', $value);
+    }
+
+    /**
+     * [last_name] filter by last name
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function email($value)
+    {
+        $this->repository->where('email', '=', $value);
+    }
+}

--- a/tests/Fixtures/ParameterQueries/PersonParameterQuery.php
+++ b/tests/Fixtures/ParameterQueries/PersonParameterQuery.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Fixtures\ParameterQueries;
 
-use EthicalJobs\Storage\ParameterQuery;
+use EthicalJobs\SDK\Storage\ParameterQuery;
 
 class PersonParameterQuery extends ParameterQuery
 {

--- a/tests/Fixtures/Repositories/FamilyDatabaseRepository.php
+++ b/tests/Fixtures/Repositories/FamilyDatabaseRepository.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Fixtures\Repositories;
 
-use EthicalJobs\Storage\CriteriaCollection;
-use EthicalJobs\Storage\DatabaseRepository;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\DatabaseRepository;
 use Tests\Fixtures\Models;
 
 class FamilyDatabaseRepository extends DatabaseRepository

--- a/tests/Fixtures/Repositories/FamilyDatabaseRepository.php
+++ b/tests/Fixtures/Repositories/FamilyDatabaseRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Fixtures\Repositories;
+
+use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\Storage\DatabaseRepository;
+use Tests\Fixtures\Models;
+
+class FamilyDatabaseRepository extends DatabaseRepository
+{
+    protected $criteria;
+
+    /**
+     * Object constructor
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct(new Models\Family);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCriteriaCollection(CriteriaCollection $collection)
+    {
+        $this->criteria = $collection;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCriteriaCollection(): CriteriaCollection
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCriteria(string $criteria)
+    {
+        $this->criteria->push($criteria);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyCriteria()
+    {
+        foreach ($this->criteria as $criteria) {
+            $criteria->apply($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Repositories/PersonDatabaseRepository.php
+++ b/tests/Fixtures/Repositories/PersonDatabaseRepository.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Fixtures\Repositories;
+
+use EthicalJobs\Storage\Contracts\Repository;
+use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\Storage\DatabaseRepository;
+use Tests\Fixtures\Models;
+
+class PersonDatabaseRepository extends DatabaseRepository
+{
+    protected $criteria;
+
+    /**
+     * Object constructor
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct(new Models\Person);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function search(string $term = ''): Repository
+    {
+        if (strlen($term) > 0) {
+            $this->query->where('first_name', 'like', "%{$term}%")
+                ->orWhere('last_name', 'like', "%{$term}%")
+                ->orWhere('age', 'like', "%{$term}%");
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCriteriaCollection(CriteriaCollection $collection)
+    {
+        $this->criteria = $collection;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCriteriaCollection(): CriteriaCollection
+    {
+        return $this->criteria;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCriteria(string $criteria)
+    {
+        $this->criteria->push($criteria);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyCriteria()
+    {
+        foreach ($this->criteria as $criteria) {
+            $criteria->apply($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Repositories/PersonDatabaseRepository.php
+++ b/tests/Fixtures/Repositories/PersonDatabaseRepository.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Fixtures\Repositories;
 
-use EthicalJobs\Storage\Contracts\Repository;
-use EthicalJobs\Storage\CriteriaCollection;
-use EthicalJobs\Storage\DatabaseRepository;
+use EthicalJobs\SDK\Storage\Contracts\Repository;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\DatabaseRepository;
 use Tests\Fixtures\Models;
 
 class PersonDatabaseRepository extends DatabaseRepository

--- a/tests/Integration/ApiClientTest.php
+++ b/tests/Integration/ApiClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Authentication/AccessTokenFetcherTest.php
+++ b/tests/Integration/Authentication/AccessTokenFetcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Authentication;
 
 use EthicalJobs\SDK\ApiClient;
@@ -34,7 +36,7 @@ class AccessTokenFetcherTest extends TestCase
             ->once()
             ->withArgs([
                 'POST',
-                'https://api.ethicalstaging.com.au/oauth/token',
+                'http://fail-connection-plox/oauth/token',
                 [
                     'json' => [
                         'grant_type' => 'password',

--- a/tests/Integration/Authentication/TokenAuthenticatorTest.php
+++ b/tests/Integration/Authentication/TokenAuthenticatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Authentication;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/HttpClient/HttpAuthenticationTest.php
+++ b/tests/Integration/HttpClient/HttpAuthenticationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\HttpClient;
 
 use EthicalJobs\SDK\Authentication\NullAuthenticator;

--- a/tests/Integration/HttpClient/HttpRequestTest.php
+++ b/tests/Integration/HttpClient/HttpRequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\HttpClient;
 
 use EthicalJobs\SDK\HttpClient;

--- a/tests/Integration/HttpClient/HttpResponseTest.php
+++ b/tests/Integration/HttpClient/HttpResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\HttpClient;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Integration/HttpClient/HttpVerbTest.php
+++ b/tests/Integration/HttpClient/HttpVerbTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\HttpClient;
 
 use EthicalJobs\SDK\HttpClient;
@@ -44,7 +46,7 @@ class HttpVerbTest extends TestCase
 
             $expected = new Request(
                 strtoupper($verb),
-                'https://api.ethicalstaging.com.au/jobs',
+                'http://fail-connection-plox/jobs',
                 [
                     'Content-Type' => 'application/json',
                     'Accept' => 'application/json',
@@ -86,7 +88,7 @@ class HttpVerbTest extends TestCase
 
         $expected = new Request(
             'GET',
-            'https://api.ethicalstaging.com.au/repos?username=andrewmclagan&forks=0&repos=1',
+            'http://fail-connection-plox/repos?username=andrewmclagan&forks=0&repos=1',
             [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',

--- a/tests/Integration/Repositories/ApiRepository/ApiRepositoryTest.php
+++ b/tests/Integration/Repositories/ApiRepository/ApiRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/CriteriaTest.php
+++ b/tests/Integration/Repositories/ApiRepository/CriteriaTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;
 use EthicalJobs\SDK\Repositories\ApiRepository;
-use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
 use Mockery;
 use Tests\TestCase;
 

--- a/tests/Integration/Repositories/ApiRepository/DeleteTest.php
+++ b/tests/Integration/Repositories/ApiRepository/DeleteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/FindByFieldTest.php
+++ b/tests/Integration/Repositories/ApiRepository/FindByFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/FindByIdTest.php
+++ b/tests/Integration/Repositories/ApiRepository/FindByIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/FindTest.php
+++ b/tests/Integration/Repositories/ApiRepository/FindTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/LimitTest.php
+++ b/tests/Integration/Repositories/ApiRepository/LimitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/OrderByTest.php
+++ b/tests/Integration/Repositories/ApiRepository/OrderByTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/SearchTest.php
+++ b/tests/Integration/Repositories/ApiRepository/SearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/UpdateCollectionTest.php
+++ b/tests/Integration/Repositories/ApiRepository/UpdateCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/UpdateTest.php
+++ b/tests/Integration/Repositories/ApiRepository/UpdateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/WhereHasInTest.php
+++ b/tests/Integration/Repositories/ApiRepository/WhereHasInTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/WhereInTest.php
+++ b/tests/Integration/Repositories/ApiRepository/WhereInTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/ApiRepository/WhereTest.php
+++ b/tests/Integration/Repositories/ApiRepository/WhereTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\ApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/JobApiRepositoryTest.php
+++ b/tests/Integration/Repositories/JobApiRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/FindByFieldTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/FindByFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/FindByIdTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/FindByIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/FindTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/FindTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/LimitTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/LimitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/OrderByTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/OrderByTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/WhereInTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/WhereInTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Repositories/TaxonomyApiRepository/WhereTest.php
+++ b/tests/Integration/Repositories/TaxonomyApiRepository/WhereTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Repositories\TaxonomyApiRepository;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/RouterTest.php
+++ b/tests/Integration/RouterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\Router;
@@ -12,31 +14,9 @@ class RouterTest extends TestCase
      * @test
      * @group Unit
      */
-    public function it_returns_correct_urls_for_host()
+    public function testTestEnvironmentUrlCorrect()
     {
-        putenv('API_HOST'); // omitting value removes the env var
-        putenv('API_SCHEME');
-        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
-
-        putenv('API_HOST');
-        putenv('API_SCHEME=https');
-        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
-
-        putenv('API_HOST=api.ethicaljobs.com.au');
-        putenv('API_SCHEME');
-        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
-
-        putenv('API_HOST=api.ethicaljobs.com.au');
-        putenv('API_SCHEME=https');
-        $this->assertEquals('https://api.ethicaljobs.com.au/jobs', Router::getRouteUrl('jobs'));
-
-        putenv('API_HOST=api.ethicalstaging.com.au');
-        putenv('API_SCHEME=https');
-        $this->assertEquals('https://api.ethicalstaging.com.au/jobs', Router::getRouteUrl('jobs'));
-
-        putenv('API_HOST=api-local');
-        putenv('API_SCHEME=http');
-        $this->assertEquals('http://api-local/jobs', Router::getRouteUrl('jobs'));
+        self::assertEquals('http://fail-connection-plox/jobs', Router::getRouteUrl('jobs'));
     }
 
     /**
@@ -48,11 +28,11 @@ class RouterTest extends TestCase
         App::shouldReceive('environment')->andReturn('production');
 
         $this->assertEquals(
-            'https://api.ethicalstaging.com.au/route/to/jobs',
+            'http://fail-connection-plox/route/to/jobs',
             Router::getRouteUrl('route/to/jobs')
         );
         $this->assertEquals(
-            'https://api.ethicalstaging.com.au/route/to/jobs',
+            'http://fail-connection-plox/route/to/jobs',
             Router::getRouteUrl('/route/to/jobs')
         );
     }

--- a/tests/Integration/Storage/CriteriaCollectionTest.php
+++ b/tests/Integration/Storage/CriteriaCollectionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Integration;
+
+use EthicalJobs\Storage\CriteriaCollection;
+use Tests\Fixtures\Criteria;
+use Tests\Fixtures\Criteria\OverFifty;
+use Tests\TestCase;
+
+class CriteriaCollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_creates_keyed_instances_when_pushing_new_criteria()
+    {
+        $collection = new CriteriaCollection;
+
+        $collection
+            ->push(Criteria\OverFifty::class)
+            ->push(Criteria\Males::class);
+
+        $this->assertEquals($collection->toArray(), [
+            Criteria\OverFifty::class => $collection->first(),
+            Criteria\Males::class => $collection->last(),
+        ]);
+    }
+}

--- a/tests/Integration/Storage/CriteriaCollectionTest.php
+++ b/tests/Integration/Storage/CriteriaCollectionTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Tests\Integration;
+namespace Tests\Integration\Storage;
 
-use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
 use Tests\Fixtures\Criteria;
-use Tests\Fixtures\Criteria\OverFifty;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class CriteriaCollectionTest extends TestCase
+class CriteriaCollectionTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/CriteriaTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/CriteriaTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
-use EthicalJobs\Storage\CriteriaCollection;
+use EthicalJobs\SDK\Storage\CriteriaCollection;
 use Tests\Fixtures\Criteria;
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class CriteriaTest extends TestCase
+class CriteriaTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/CriteriaTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/CriteriaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use EthicalJobs\Storage\CriteriaCollection;
+use Tests\Fixtures\Criteria;
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class CriteriaTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function its_criteria_are_an_empty_collection_by_default()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $criteria = $repository->getCriteriaCollection();
+
+        $this->assertInstanceOf(CriteriaCollection::class, $criteria);
+
+        $this->assertTrue($criteria->isEmpty());
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_set_and_get_it_criteria_collection()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $collection = new CriteriaCollection([
+            Criteria\Males::class,
+            Criteria\OverFifty::class,
+        ]);
+
+        $repository->setCriteriaCollection($collection);
+
+        $this->assertEquals($repository->getCriteriaCollection(), $collection);
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_add_criteria_items()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $expected = $repository->addCriteria(Criteria\OverFifty::class)
+            ->getCriteriaCollection()
+            ->get(Criteria\OverFifty::class);
+
+        $this->assertEquals(new Criteria\OverFifty, $expected);
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_apply_criteria()
+    {
+        $firstCount = 1;
+        while($firstCount <= 5) {
+            (new ModelMock(Models\Person::class))->create(['age' => 29]);
+            (new ModelMock(Models\Person::class))->create(['age' => 55]);
+            $firstCount++;
+        }
+
+        $repository = new PersonDatabaseRepository;
+
+        $people = $repository
+            ->addCriteria(Criteria\OverFifty::class)
+            ->find();
+
+        $people->each(function ($person) {
+            $this->assertTrue($person->age > 50);
+        });
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/DeleteTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/DeleteTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class DeleteTest extends TestCase
+class DeleteTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/DeleteTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/DeleteTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class DeleteTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_delete_an_entity_and_return_it()
+    {
+        $person = (new ModelMock(Models\Person::class))->create([]);
+
+        $this->assertTrue($person->deleted_at === null);
+
+        $repository = new PersonDatabaseRepository;
+
+        $deleted = $repository->delete($person->id);
+
+        $this->assertTrue($deleted->deleted_at !== null);
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/FindByFieldTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindByFieldTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class FindByFieldTest extends TestCase
+class FindByFieldTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/FindByFieldTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindByFieldTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class FindByFieldTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_find_by_a_field()
+    {
+        $person = (new ModelMock(Models\Person::class))->create();
+
+        $repository = new PersonDatabaseRepository;
+
+        $found = $repository
+            ->findByField('first_name', $person->first_name);
+
+        $this->assertEquals($person->first_name, $found->first_name);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_returns_null_when_no_model_found()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $this->assertEquals(
+            $repository->findByField('first_name', 'Jesus'),
+            null
+        );
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/FindByIdTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindByIdTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class FindByIdTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_returns_a_model_if_one_is_passed_in()
+    {
+        $person = (new ModelMock(Models\Person::class))->create();
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository->findById($person);
+
+        $this->assertEquals($person->id, $result->id);
+        $this->assertEquals($person->first_name, $result->first_name);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_find_by_id()
+    {
+        $person = (new ModelMock(Models\Person::class))->create();
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository->findById($person->id);
+
+        $this->assertEquals($person->id, $result->id);
+        $this->assertEquals($person->first_name, $result->first_name);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_returns_null_when_no_model_found()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $this->assertEquals(
+            $repository->findById(1337),
+            null
+        );
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/FindByIdTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindByIdTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class FindByIdTest extends TestCase
+class FindByIdTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/FindTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class FindTest extends TestCase
+class FindTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/FindTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/FindTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class FindTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_execute_the_query()
+    {
+        $firstCount = 1;
+        while($firstCount <= 10) {
+            (new ModelMock(Models\Person::class))->create();
+            $firstCount++;
+        }
+
+        $repository = new PersonDatabaseRepository;
+
+        $results = $repository->find();
+
+        $results->each(function ($result) {
+            $this->assertInstanceOf(Models\Person::class, $result);
+        });
+
+        $this->assertEquals(10, $results->count());
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_returns_empty_iterable_if_results_empty()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $results = $repository->find();
+
+        $this->assertEquals(0, $results->count());
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/LimitTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/LimitTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class LimitTest extends TestCase
+class LimitTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/LimitTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/LimitTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class LimitTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_has_fluent_interface()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $isFluent = $repository->limit(5);
+
+        $this->assertInstanceOf(PersonDatabaseRepository::class, $isFluent);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_add_a_where_query()
+    {
+        $firstCount = 1;
+        while($firstCount <= 20) {
+            (new ModelMock(Models\Person::class))->create();
+            $firstCount++;
+        }
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository
+            ->limit(15)
+            ->find();
+
+        $this->assertEquals(15, $result->count());
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/OrderByTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/OrderByTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class OrderByTest extends TestCase
+class OrderByTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/OrderByTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/OrderByTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class OrderByTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_has_fluent_interface()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $isFluent = $repository
+            ->orderBy('status', 'asc');
+
+        $this->assertInstanceOf(PersonDatabaseRepository::class, $isFluent);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_add_an_OrderBy_query()
+    {
+        (new ModelMock(Models\Person::class))->create(['age' => 15]);
+        (new ModelMock(Models\Person::class))->create(['age' => 15]);
+        (new ModelMock(Models\Person::class))->create(['age' => 31]);
+        (new ModelMock(Models\Person::class))->create(['age' => 70]);
+        (new ModelMock(Models\Person::class))->create(['age' => 60]);
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository
+            ->orderBy('age', 'asc')
+            ->find();
+
+        $agesInOrder = $result->pluck('age')->toArray();
+
+        $this->assertEquals($agesInOrder, [
+            '15',
+            '15',
+            '31',
+            '60',
+            '70',
+        ]);
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/PersonDatabaseRepositoryTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/PersonDatabaseRepositoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Integration\Storage\DatabaseRepository;
+
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\StorageTestCase;
+
+class PersonDatabaseRepositoryTest extends StorageTestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_set_and_get_its_storage_engine()
+    {
+        // Via constructor
+        $repository = new PersonDatabaseRepository;
+        $this->assertEquals($repository->getStorageEngine(), (new Models\Person)->query());
+
+        // Via method
+        $repository = new PersonDatabaseRepository;
+        $repository->setStorageEngine((new Models\Family)->query());
+        $this->assertEquals($repository->getStorageEngine(), (new Models\Family)->query());
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/UpdateCollectionTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/UpdateCollectionTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Illuminate\Support\Collection;
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class UpdateCollectionTest extends TestCase
+class UpdateCollectionTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/UpdateCollectionTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/UpdateCollectionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Illuminate\Support\Collection;
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class UpdateCollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_updates_a_collection_of_entities()
+    {
+        $firstCount = 1;
+        $peopleToUpdate = new Collection();
+        while($firstCount <= 6) {
+            $peopleToUpdate->push((new ModelMock(Models\Person::class))->create());
+            $firstCount++;
+        }
+        $peopleToUpdate = $peopleToUpdate->map(function ($person) {
+            return [
+                'id' => $person->id,
+                'first_name' => 'Andrew',
+                'last_name' => 'McLagan',
+            ];
+        })->keyBy('id');
+
+        $repository = new PersonDatabaseRepository;
+
+        $updatedPeople = $repository->updateCollection($peopleToUpdate);
+
+        $updatedPeople->each(function ($person) {
+            $this->assertEquals($person->first_name, 'Andrew');
+            $this->assertEquals($person->last_name, 'McLagan');
+        });
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_accept_arrays_when_updating()
+    {
+        $firstCount = 1;
+        $peopleToUpdate = new Collection();
+        while($firstCount <= 6) {
+            $peopleToUpdate->push((new ModelMock(Models\Person::class))->create());
+            $firstCount++;
+        }
+        $peopleToUpdate = $peopleToUpdate->map(function ($person) {
+            return [
+                'id' => $person->id,
+                'first_name' => 'Andrew',
+                'last_name' => 'McLagan',
+            ];
+        })
+        ->keyBy('id')
+        ->toArray();
+
+        $repository = new PersonDatabaseRepository;
+
+        $updatedPeople = $repository->updateCollection($peopleToUpdate);
+
+        $updatedPeople->each(function ($person) {
+            $this->assertEquals($person->first_name, 'Andrew');
+            $this->assertEquals($person->last_name, 'McLagan');
+        });
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_returns_all_updated_entities()
+    {
+        $firstCount = 1;
+        $peopleToUpdate = new Collection();
+        while($firstCount <= 6) {
+            $peopleToUpdate->push((new ModelMock(Models\Person::class))->create());
+            $firstCount++;
+        }
+        $peopleToUpdate = $peopleToUpdate->map(function ($person) {
+            return [
+                'id' => $person->id,
+                'first_name' => 'Andrew',
+                'last_name' => 'McLagan',
+            ];
+        })
+        ->keyBy('id');
+
+        $repository = new PersonDatabaseRepository;
+
+        $updatedPeople = $repository->updateCollection($peopleToUpdate);
+
+        $updatedPeople->each(function ($person) use ($peopleToUpdate) {
+            $this->assertTrue($peopleToUpdate->has($person->id));
+        });
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/UpdateTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/UpdateTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class UpdateTest extends TestCase
+class UpdateTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/UpdateTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/UpdateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_update_an_entity_and_return_it()
+    {
+        $person = (new ModelMock(Models\Person::class))->create();
+
+        $repository = new PersonDatabaseRepository;
+
+        $updated = $repository->update($person, [
+            'first_name' => 'Andrew',
+            'last_name' => 'McLagan',
+        ]);
+
+        $this->assertTrue($updated->first_name === 'Andrew');
+        $this->assertTrue($updated->last_name === 'McLagan');
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/WhereHasInTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereHasInTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Illuminate\Support\Collection;
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\FamilyDatabaseRepository;
+use Tests\TestCase;
+
+class WhereHasInTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_has_fluent_interface()
+    {
+        $repository = new FamilyDatabaseRepository;
+
+        $isFluent = $repository->whereHasIn('people.id', [12, 22]);
+
+        $this->assertInstanceOf(FamilyDatabaseRepository::class, $isFluent);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_query_relationship_values()
+    {
+        $trumps = (new ModelMock(Models\Family::class))->create();
+        $obamas = (new ModelMock(Models\Family::class))->create();
+
+        $firstCount = 1;
+        while($firstCount <= 7) {
+            (new ModelMock(Models\Person::class))->create(['family_id' => $trumps->id]);
+            $firstCount++;
+        }
+
+        $secondCount = 1;
+        while($secondCount <= 4) {
+            (new ModelMock(Models\Person::class))->create(['family_id' => $obamas->id]);
+            $secondCount++;
+        }
+
+        $randomTrumps = $trumps->people
+            ->random(2)
+            ->pluck('id')
+            ->toArray();
+
+        $repository = new FamilyDatabaseRepository;
+
+        $result = $repository
+            ->whereHasIn('people.id', $randomTrumps)
+            ->find();
+
+        foreach ($result as $shouldBeATrump) {
+            $this->assertTrue(
+                $trumps->people->contains($shouldBeATrump->id)
+            );
+            $this->assertFalse(
+                $obamas->people->contains($shouldBeATrump->id)
+            );
+        }
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_query_relationship_values_with_other_fields()
+    {
+        $trumps = (new ModelMock(Models\Family::class))->create();
+
+        (new ModelMock(Models\Person::class))->create([
+            'family_id' => $trumps->id,
+            'age' => 75,
+        ]);
+        (new ModelMock(Models\Person::class))->create([
+            'family_id' => $trumps->id,
+            'age' => 42,
+        ]);
+
+        $obamas = (new ModelMock(Models\Family::class))->create();
+
+        (new ModelMock(Models\Person::class))->create([
+            'family_id' => $obamas->id,
+            'age' => 32,
+        ]);
+        (new ModelMock(Models\Person::class))->create([
+            'family_id' => $obamas->id,
+            'age' => 8,
+        ]);
+
+        $repository = new FamilyDatabaseRepository;
+
+        $result = $repository
+            ->whereHasIn('people.age', [42, 8])
+            ->find();
+
+        foreach ($result as $family) {
+            $agesOfMembers = $family->people->pluck('age');
+
+            $this->assertTrue(
+                $agesOfMembers->contains(42) || $agesOfMembers->contains(8)
+            );
+        }
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/WhereHasInTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereHasInTest.php
@@ -1,14 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
-use Illuminate\Support\Collection;
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\FamilyDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class WhereHasInTest extends TestCase
+class WhereHasInTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/WhereInTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereInTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class WhereInTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_has_fluent_interface()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $isFluent = $repository
+            ->whereIn('status', ['APPROVED', 'DRAFT']);
+
+        $this->assertInstanceOf(PersonDatabaseRepository::class, $isFluent);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_add_a_where_query()
+    {
+        (new ModelMock(Models\Person::class))->create(['age' => 21]);
+        (new ModelMock(Models\Person::class))->create(['age' => 34]);
+        (new ModelMock(Models\Person::class))->create(['age' => 16]);
+        (new ModelMock(Models\Person::class))->create(['age' => 34]);
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository
+            ->whereIn('age', [21, 34])
+            ->find();
+
+        $agesSelected = $result->pluck('age')->toArray();
+
+        $this->assertEquals($agesSelected, [
+            '21',
+            '34',
+            '34',
+        ]);
+    }
+}

--- a/tests/Integration/Storage/DatabaseRepository/WhereInTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereInTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class WhereInTest extends TestCase
+class WhereInTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/WhereTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Integration\Storage\DatabaseRepository;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class WhereTest extends TestCase
+class WhereTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/DatabaseRepository/WhereTest.php
+++ b/tests/Integration/Storage/DatabaseRepository/WhereTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class WhereTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_has_fluent_interface()
+    {
+        $repository = new PersonDatabaseRepository;
+
+        $isFluent = $repository
+            ->where('first_name', '!=', 'Andrew');
+
+        $this->assertInstanceOf(PersonDatabaseRepository::class, $isFluent);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_add_a_where_query()
+    {
+        (new ModelMock(Models\Person::class))->create(['age' => 21]);
+        (new ModelMock(Models\Person::class))->create(['age' => 22]);
+        (new ModelMock(Models\Person::class))->create(['age' => 23]);
+
+        $repository = new PersonDatabaseRepository;
+
+        $result = $repository
+            ->where('age', '!=', 22)
+            ->find();
+
+        $selectedPeople = $result->pluck('age')->toArray();
+
+        $this->assertEquals($selectedPeople, [
+            '21',
+            '23',
+        ]);
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/DateFromTest.php
+++ b/tests/Integration/Storage/ParameterQuery/DateFromTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Carbon\Carbon;
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class DateFromTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_maps_an_dateFrom_parameter()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'iraS',
+            'created_at' => Carbon::now()->addDays(5),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Werdna',
+            'created_at' => Carbon::now()->addDays(5),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Divad',
+            'created_at' => Carbon::now()->subDays(3),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'ydnas',
+            'created_at' => Carbon::now()->subDays(3),
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'dateFrom' => (string)Carbon::tomorrow(),
+        ]);
+
+        $this->assertEquals(2, $people->count());
+
+        foreach ($people as $person) {
+            $this->assertTrue($person->created_at->gte(Carbon::tomorrow()));
+        }
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/DateFromTest.php
+++ b/tests/Integration/Storage/ParameterQuery/DateFromTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Carbon\Carbon;
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class DateFromTest extends TestCase
+class DateFromTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/DateToTest.php
+++ b/tests/Integration/Storage/ParameterQuery/DateToTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Carbon\Carbon;
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class DateToTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_maps_an_dateFrom_parameter()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'iraS',
+            'created_at' => Carbon::now()->addDays(5),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Werdna',
+            'created_at' => Carbon::now()->addDays(5),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Divad',
+            'created_at' => Carbon::now()->subDays(3),
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'ydnas',
+            'created_at' => Carbon::now()->subDays(3),
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'dateTo' => (string)Carbon::tomorrow(),
+        ]);
+
+        $this->assertEquals(2, $people->count());
+
+        foreach ($people as $person) {
+            $this->assertTrue($person->created_at->lte(Carbon::tomorrow()));
+        }
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/DateToTest.php
+++ b/tests/Integration/Storage/ParameterQuery/DateToTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Carbon\Carbon;
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class DateToTest extends TestCase
+class DateToTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/LimitTest.php
+++ b/tests/Integration/Storage/ParameterQuery/LimitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class LimitTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_maps_a_limit_parameter()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'iraS',
+            'age' => 44,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Werdna',
+            'age' => 34,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Divad',
+            'age' => 36,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'ydnas',
+            'age' => 38,
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'limit' => 2,
+        ]);
+
+        $this->assertEquals(2, $people->count());
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/LimitTest.php
+++ b/tests/Integration/Storage/ParameterQuery/LimitTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class LimitTest extends TestCase
+class LimitTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/OrderByTest.php
+++ b/tests/Integration/Storage/ParameterQuery/OrderByTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class OrderByTest extends TestCase
+class OrderByTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/OrderByTest.php
+++ b/tests/Integration/Storage/ParameterQuery/OrderByTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class OrderByTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_maps_an_orderBy_parameter()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'iraS',
+            'age' => 44,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Werdna',
+            'age' => 34,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Divad',
+            'age' => 36,
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'ydnas',
+            'age' => 38,
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'orderBy' => 'age',
+        ]);
+
+        $this->assertEquals('iraS', $people[3]->first_name);
+        $this->assertEquals('ydnas', $people[2]->first_name);
+        $this->assertEquals('Divad', $people[1]->first_name);
+        $this->assertEquals('Werdna', $people[0]->first_name);
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/ParameterQueryTest.php
+++ b/tests/Integration/Storage/ParameterQuery/ParameterQueryTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class ParameterQueryTest extends TestCase
+class ParameterQueryTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/ParameterQueryTest.php
+++ b/tests/Integration/Storage/ParameterQuery/ParameterQueryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class ParameterQueryTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_set_and_get_its_repository()
+    {
+        $personRepository = new PersonDatabaseRepository;
+
+        $paramQuery = new PersonParameterQuery($personRepository);
+
+        $this->assertEquals($personRepository, $paramQuery->getRepository());
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_queries_by_parameters()
+    {
+        $expectedPerson = (new ModelMock(Models\Person::class))->create([
+            'age' => 65,
+            'email' => 'andrew@ethicaljobs.com.au',
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'age' => 45,
+            'email' => 'andrew@ethicaljobs.com.au',
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'ages' => [23, 65, 55, 18],
+            'email' => 'andrew@ethicaljobs.com.au',
+        ]);
+
+        $person = $people->first();
+
+        $this->assertEquals($expectedPerson->id, $person->id);
+        $this->assertEquals($expectedPerson->first_name, $person->first_name);
+    }
+
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_can_call_snake_or_camel_case_param_funcs()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'last_name' => 'mclagan',
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'last_name' => 'kisilevsky',
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'last_name' => 'mclagan',
+        ]);
+
+        foreach ($people as $person) {
+            $this->assertEquals($person->last_name, 'mclagan');
+        }
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'lastName' => 'mclagan',
+        ]);
+
+        foreach ($people as $person) {
+            $this->assertEquals($person->last_name, 'mclagan');
+        }
+    }
+}

--- a/tests/Integration/Storage/ParameterQuery/SearchTest.php
+++ b/tests/Integration/Storage/ParameterQuery/SearchTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\Integration\ParameterQuery;
+namespace Tests\Integration\Storage\ParameterQuery;
 
 use Tests\Fixtures\ModelMock;
 use Tests\Fixtures\Models;
 use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
 use Tests\Fixtures\Repositories\PersonDatabaseRepository;
-use Tests\TestCase;
+use Tests\StorageTestCase;
 
-class SearchTest extends TestCase
+class SearchTest extends StorageTestCase
 {
     /**
      * @test

--- a/tests/Integration/Storage/ParameterQuery/SearchTest.php
+++ b/tests/Integration/Storage/ParameterQuery/SearchTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Integration\ParameterQuery;
+
+use Tests\Fixtures\ModelMock;
+use Tests\Fixtures\Models;
+use Tests\Fixtures\ParameterQueries\PersonParameterQuery;
+use Tests\Fixtures\Repositories\PersonDatabaseRepository;
+use Tests\TestCase;
+
+class SearchTest extends TestCase
+{
+    /**
+     * @test
+     * @group Integration
+     */
+    public function it_maps_a_search_parameter()
+    {
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Sari',
+            'last_name' => 'Korin Kisilevsky',
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Werdna',
+            'last_name' => 'Ssor Nagalcm',
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'Divad',
+            'last_name' => 'ttocs Nagalcm',
+        ]);
+
+        (new ModelMock(Models\Person::class))->create([
+            'first_name' => 'ydnas',
+            'last_name' => 'gerg Nagalcm',
+        ]);
+
+        $paramQuery = new PersonParameterQuery(new PersonDatabaseRepository);
+
+        $people = $paramQuery->find([
+            'q' => 'Kisilevsky',
+        ]);
+
+        $this->assertEquals(1, $people->count());
+
+        $shouldBeSari = $people->first();
+
+        $this->assertEquals('Sari', $shouldBeSari->first_name);
+    }
+}

--- a/tests/Integration/Testing/MockingTest.php
+++ b/tests/Integration/Testing/MockingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Testing;
 
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/Testing/ResponseFactoryTest.php
+++ b/tests/Integration/Testing/ResponseFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration\Testing;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/StorageTestCase.php
+++ b/tests/StorageTestCase.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests;
+
+use Exception;
+use Illuminate\Contracts\Foundation\Application;
+use Orchestra\Database\ConsoleServiceProvider;
+use Tests\Fixtures\Models;
+
+abstract class StorageTestCase extends \Orchestra\Testbench\TestCase
+{
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     * @throws Exception
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+
+        $this->withFactories(__DIR__ . '/../database/factories');
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('elasticsearch.index', 'testing');
+
+        $app['config']->set('elasticsearch.indexables', [
+            Models\Person::class,
+            Models\Family::class,
+            Models\Vehicle::class,
+        ]);
+
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    /**
+     * Inject package service provider
+     *
+     * @param Application $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            ConsoleServiceProvider::class,
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use EthicalJobs\SDK\Laravel\ServiceProvider;
@@ -19,8 +21,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        putenv('API_HOST=api.ethicalstaging.com.au'); // don't use production in case a test mutates data
-        putenv('API_SCHEME=https');
+        putenv('API_HOST=fail-connection-plox'); // don't rely on live external services for tests
+        putenv('API_SCHEME=http');
     }
 
     /**

--- a/tests/Unit/Collection/CollectionTest.php
+++ b/tests/Unit/Collection/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Collection;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Unit/Enumerables/JobStatusTest.php
+++ b/tests/Unit/Enumerables/JobStatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Enumerables\JobStatus;

--- a/tests/Unit/LegacyCollectionTest.php
+++ b/tests/Unit/LegacyCollectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Integration\Repositories\Database;
+namespace Tests\Unit;
 
 use Illuminate\Support\Collection;
 use Tests\Fixtures\Collections;

--- a/tests/Unit/LegacyCollectionTest.php
+++ b/tests/Unit/LegacyCollectionTest.php
@@ -7,7 +7,7 @@ use Tests\Fixtures\Collections;
 use Tests\Fixtures\Models;
 use Tests\TestCase;
 
-class CollectionTest extends TestCase
+class LegacyCollectionTest extends TestCase
 {
     /**
      * @test

--- a/tests/Unit/LegacyCollectionTest.php
+++ b/tests/Unit/LegacyCollectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Integration\Repositories\Database;
+
+use Illuminate\Support\Collection;
+use Tests\Fixtures\Collections;
+use Tests\Fixtures\Models;
+use Tests\TestCase;
+
+class CollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_create_an_instance_of_an_item()
+    {
+        $this->assertInstanceOf(
+            Models\Person::class,
+            Collections\ModelsCollection::instance('people')
+        );
+
+        $this->assertInstanceOf(
+            Models\Family::class,
+            Collections\ModelsCollection::instance('families')
+        );
+
+        $this->assertInstanceOf(
+            Models\Vehicle::class,
+            Collections\ModelsCollection::instance('vehicles')
+        );
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_returns_null_if_instance_does_not_exist()
+    {
+        $this->assertEquals(
+            null,
+            Collections\ModelsCollection::instance('animals')
+        );
+
+        $this->assertEquals(
+            null,
+            Collections\ModelsCollection::instance('planets')
+        );
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_return_a_collection_of_instances()
+    {
+        $instances = Collections\ModelsCollection::instances();
+
+        $expected = new Collection([
+            'families' => new Models\Family,
+            'people' => new Models\Person,
+            'vehicles' => new Models\Vehicle,
+        ]);
+
+        $this->assertEquals($expected, $instances);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_is_arrayable()
+    {
+        $collection = new Collections\ModelsCollection;
+
+        $this->assertEquals($collection->all(), [
+            'families' => Models\Family::class,
+            'people' => Models\Person::class,
+            'vehicles' => Models\Vehicle::class,
+        ]);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_can_return_collection_keys()
+    {
+        $collection = new Collections\ModelsCollection;
+
+        $this->assertEquals($collection->keys()->toArray(), [
+            'families',
+            'people',
+            'vehicles',
+        ]);
+    }
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function it_is_backwards_compatible_with_previous_instantiation()
+    {
+        $collection = new Collections\BackWardsCompatible;
+
+        $this->assertEquals($collection->all(), [
+            'families' => Models\Family::class,
+            'people' => Models\Person::class,
+            'vehicles' => Models\Vehicle::class,
+        ]);
+    }
+}

--- a/tests/Unit/ResponseSelector/EntitiesTest.php
+++ b/tests/Unit/ResponseSelector/EntitiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Unit/ResponseSelector/EntitiyByResultTest.php
+++ b/tests/Unit/ResponseSelector/EntitiyByResultTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Unit/ResponseSelector/EntityByIdTest.php
+++ b/tests/Unit/ResponseSelector/EntityByIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Unit/ResponseSelector/ResponseSelectorTest.php
+++ b/tests/Unit/ResponseSelector/ResponseSelectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Collection;

--- a/tests/Unit/ResponseSelector/ResultsTest.php
+++ b/tests/Unit/ResponseSelector/ResultsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use EthicalJobs\SDK\Collection;


### PR DESCRIPTION
This has a dependency on laravel-storage, forcing any repo which uses SDK-PHP to thus depend on laravel-storage. This is an arbitrary dependency given our architecture landscape - in that all Laravel repos require this "sdk" (noting unfortunately despite the name it isn't a generic PHP SDK given the tight coupling to Laravel).

I've done my best to ignore the issues not up to our coding standard and to focus on just upgrading PHP and merging laravel-storage in.